### PR TITLE
Fix DidParser accepting DID URLs and illegal characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **did:peer purpose codes**: Aligned with the current DIF peer-DID spec. `KeyAgreement` now uses prefix `E` (was `A`). Added three new `PeerPurpose` members: `Assertion` (prefix `A`), `CapabilityInvocation` (prefix `I`), and `CapabilityDelegation` (prefix `D`). All five W3C DID Core verification relationships are now supported in numalgo 2.
 
+### Fixed
+
+- **DID parser validation**: `DidParser.IsValid` now enforces W3C DID Core ABNF — rejects DID URLs (fragments, queries, paths, parameters), spaces, and other illegal characters. The `Did` value object now truly guarantees syntactic validity.
+- **DID URL parameter parsing**: `DidParser.ParseDidUrl` now correctly parses DID parameters (`;param=value`), modeled via new `DidUrl.Parameters` property.
+
 ## [0.2.0] - 2026-03-08
 
 ### Added

--- a/src/NetDid.Core/Model/DidUrl.cs
+++ b/src/NetDid.Core/Model/DidUrl.cs
@@ -1,12 +1,16 @@
 namespace NetDid.Core.Model;
 
 /// <summary>
-/// A parsed DID URL: DID + optional path, query, and fragment.
+/// A parsed DID URL: DID + optional path, parameters, query, and fragment.
 /// </summary>
 public sealed record DidUrl
 {
     public required Did Did { get; init; }
     public string? Path { get; init; }
+
+    /// <summary>DID parameters (the portion after ';' and before '?' or '#').</summary>
+    public string? Parameters { get; init; }
+
     public string? Query { get; init; }
     public string? Fragment { get; init; }
 
@@ -16,6 +20,7 @@ public sealed record DidUrl
         {
             var url = Did.Value;
             if (Path is not null) url += Path;
+            if (Parameters is not null) url += ";" + Parameters;
             if (Query is not null) url += "?" + Query;
             if (Fragment is not null) url += "#" + Fragment;
             return url;

--- a/src/NetDid.Core/Parsing/DidParser.cs
+++ b/src/NetDid.Core/Parsing/DidParser.cs
@@ -10,16 +10,22 @@ public static partial class DidParser
 {
     // W3C DID ABNF: did = "did:" method-name ":" method-specific-id
     // method-name = 1*method-char, method-char = %x61-7A / DIGIT (lowercase + digits)
-    // method-specific-id = *( *idchar ":" ) 1*idchar, idchar = ALPHA / DIGIT / "." / "-" / "_" / pct-encoded
-    [GeneratedRegex(@"^did:[a-z0-9]+:.+$", RegexOptions.Compiled)]
+    // method-specific-id = *( *idchar ":" ) 1*idchar
+    // idchar = ALPHA / DIGIT / "." / "-" / "_" / pct-encoded
+    // pct-encoded = "%" HEXDIG HEXDIG
+    private const string IdCharPattern = @"[A-Za-z0-9._-]|%[0-9A-Fa-f]{2}";
+    private const string MethodSpecificIdPattern = $@"(?:(?:{IdCharPattern})*:)*(?:{IdCharPattern})+";
+
+    [GeneratedRegex($@"^did:[a-z0-9]+:{MethodSpecificIdPattern}$", RegexOptions.Compiled)]
     private static partial Regex DidRegex();
 
-    // DID URL: did-url = did path-abempty [ "?" query ] [ "#" fragment ]
-    [GeneratedRegex(@"^(?<did>did:[a-z0-9]+:[^?#/]+)(?<path>/[^?#]*)?(?:\?(?<query>[^#]*))?(?:#(?<fragment>.*))?$", RegexOptions.Compiled)]
+    // DID URL: did-url = did path-abempty [ ";" params ] [ "?" query ] [ "#" fragment ]
+    [GeneratedRegex($@"^(?<did>did:[a-z0-9]+:(?:(?:{IdCharPattern})*:)*(?:{IdCharPattern})+)(?<path>/[^;?#]*)?(?:;(?<params>[^?#]*))?(?:\?(?<query>[^#]*))?(?:#(?<fragment>.*))?$", RegexOptions.Compiled)]
     private static partial Regex DidUrlRegex();
 
     /// <summary>
-    /// Validate a DID string conforms to W3C DID syntax: did:&lt;method&gt;:&lt;method-specific-id&gt;
+    /// Validate a bare DID string conforms to W3C DID syntax: did:&lt;method&gt;:&lt;method-specific-id&gt;.
+    /// Rejects DID URLs (paths, queries, fragments, parameters).
     /// </summary>
     public static bool IsValid(string did)
     {
@@ -50,7 +56,7 @@ public static partial class DidParser
         return did[(secondColon + 1)..];
     }
 
-    /// <summary>Parse a DID URL (DID + optional path, query, fragment).</summary>
+    /// <summary>Parse a DID URL (DID + optional path, params, query, fragment).</summary>
     public static DidUrl? ParseDidUrl(string didUrl)
     {
         if (string.IsNullOrEmpty(didUrl))
@@ -64,14 +70,20 @@ public static partial class DidParser
         if (!IsValid(didStr))
             return null;
 
-        var path = match.Groups["path"].Success ? match.Groups["path"].Value : null;
-        var query = match.Groups["query"].Success ? match.Groups["query"].Value : null;
-        var fragment = match.Groups["fragment"].Success ? match.Groups["fragment"].Value : null;
+        var path = match.Groups["path"].Success && match.Groups["path"].Value.Length > 0
+            ? match.Groups["path"].Value : null;
+        var parameters = match.Groups["params"].Success && match.Groups["params"].Value.Length > 0
+            ? match.Groups["params"].Value : null;
+        var query = match.Groups["query"].Success && match.Groups["query"].Value.Length > 0
+            ? match.Groups["query"].Value : null;
+        var fragment = match.Groups["fragment"].Success && match.Groups["fragment"].Value.Length > 0
+            ? match.Groups["fragment"].Value : null;
 
         return new DidUrl
         {
             Did = new Did(didStr),
             Path = path,
+            Parameters = parameters,
             Query = query,
             Fragment = fragment
         };

--- a/tests/NetDid.Core.Tests/Parsing/DidParserTests.cs
+++ b/tests/NetDid.Core.Tests/Parsing/DidParserTests.cs
@@ -12,6 +12,10 @@ public class DidParserTests
     [InlineData("did:ethr:0x1:0xabc123")]
     [InlineData("did:example:123")]
     [InlineData("did:a:1")]
+    [InlineData("did:example:abc%20def")]       // percent-encoded
+    [InlineData("did:example:with.dots")]
+    [InlineData("did:example:with-dashes")]
+    [InlineData("did:example:with_underscores")]
     public void IsValid_ValidDids_ReturnsTrue(string did)
     {
         DidParser.IsValid(did).Should().BeTrue();
@@ -25,6 +29,13 @@ public class DidParserTests
     [InlineData("did::something")]
     [InlineData("DID:key:abc")]
     [InlineData("did:KEY:abc")]
+    [InlineData("did:example:abc#frag")]         // DID URL, not a bare DID
+    [InlineData("did:example:abc?query=1")]      // DID URL with query
+    [InlineData("did:example:abc/path")]         // DID URL with path
+    [InlineData("did:example:abc def")]          // space is illegal
+    [InlineData("did:example:abc{brace}")]       // braces are illegal
+    [InlineData("did:example:abc<angle>")]       // angle brackets illegal
+    [InlineData("did:example:abc;param=val")]    // DID URL with parameters
     public void IsValid_InvalidDids_ReturnsFalse(string did)
     {
         DidParser.IsValid(did).Should().BeFalse();
@@ -60,6 +71,24 @@ public class DidParserTests
         DidParser.ExtractMethodSpecificId(did).Should().Be(expectedId);
     }
 
+    // --- Did value object ---
+
+    [Fact]
+    public void Did_RejectsDidUrl()
+    {
+        var act = () => new NetDid.Core.Model.Did("did:example:abc#frag");
+        act.Should().Throw<NetDid.Core.Exceptions.InvalidDidException>();
+    }
+
+    [Fact]
+    public void Did_RejectsSpaces()
+    {
+        var act = () => new NetDid.Core.Model.Did("did:example:abc def");
+        act.Should().Throw<NetDid.Core.Exceptions.InvalidDidException>();
+    }
+
+    // --- DID URL parsing ---
+
     [Fact]
     public void ParseDidUrl_BareDid_ReturnsParsedUrl()
     {
@@ -68,6 +97,7 @@ public class DidParserTests
         result.Should().NotBeNull();
         result!.Did.Value.Should().Be("did:key:z6Mk");
         result.Path.Should().BeNull();
+        result.Parameters.Should().BeNull();
         result.Query.Should().BeNull();
         result.Fragment.Should().BeNull();
     }
@@ -102,6 +132,29 @@ public class DidParserTests
     }
 
     [Fact]
+    public void ParseDidUrl_WithParameters_ParsesCorrectly()
+    {
+        var result = DidParser.ParseDidUrl("did:example:abc;service=files");
+
+        result.Should().NotBeNull();
+        result!.Did.Value.Should().Be("did:example:abc");
+        result.Parameters.Should().Be("service=files");
+        result.Query.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseDidUrl_WithParametersAndQuery_ParsesCorrectly()
+    {
+        var result = DidParser.ParseDidUrl("did:example:abc;service=files?version=2#key-1");
+
+        result.Should().NotBeNull();
+        result!.Did.Value.Should().Be("did:example:abc");
+        result.Parameters.Should().Be("service=files");
+        result.Query.Should().Be("version=2");
+        result.Fragment.Should().Be("key-1");
+    }
+
+    [Fact]
     public void ParseDidUrl_Invalid_ReturnsNull()
     {
         DidParser.ParseDidUrl("not-a-did-url").Should().BeNull();
@@ -111,6 +164,16 @@ public class DidParserTests
     public void ParseDidUrl_FullUrl_ReconstructsCorrectly()
     {
         var url = "did:key:z6Mk?service=hub#key-1";
+        var result = DidParser.ParseDidUrl(url);
+
+        result.Should().NotBeNull();
+        result!.FullUrl.Should().Be(url);
+    }
+
+    [Fact]
+    public void ParseDidUrl_WithParameters_ReconstructsCorrectly()
+    {
+        var url = "did:example:abc;service=files?version=2#key-1";
         var result = DidParser.ParseDidUrl(url);
 
         result.Should().NotBeNull();


### PR DESCRIPTION
## Summary
- Replace permissive `.+` regex with W3C DID Core ABNF-compliant validation for bare DIDs
- `DidParser.IsValid` now rejects DID URLs (fragments, queries, paths, parameters), spaces, braces, angle brackets, and other illegal characters
- Add DID parameter parsing (`;param=value`) to `DidUrl` via new `Parameters` property
- `DidUrl.FullUrl` round-trips correctly with parameters

## Test plan
- [ ] All 266 tests pass (16 new regression tests for parser)
- [ ] `new Did("did:example:abc#frag")` throws `InvalidDidException`
- [ ] `DidParser.ParseDidUrl("did:example:abc;service=files")` correctly separates DID from parameters

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)