### PR TITLE
Strip private JWK key material from serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **DID parser validation**: `DidParser.IsValid` now enforces W3C DID Core ABNF — rejects DID URLs (fragments, queries, paths, parameters), spaces, and other illegal characters. The `Did` value object now truly guarantees syntactic validity.
 - **DID URL parameter parsing**: `DidParser.ParseDidUrl` now correctly parses DID parameters (`;param=value`), modeled via new `DidUrl.Parameters` property.
+- **Private JWK key leak**: `DidDocumentSerializer` no longer emits private key member `d` from `publicKeyJwk`. Only public JWK members (`kty`, `crv`, `x`, `y`) are serialized.
 
 ## [0.2.0] - 2026-03-08
 

--- a/src/NetDid.Core/Serialization/DidDocumentSerializer.cs
+++ b/src/NetDid.Core/Serialization/DidDocumentSerializer.cs
@@ -311,12 +311,12 @@ public static class DidDocumentSerializer
 
         private static void WriteJwk(Utf8JsonWriter writer, JsonWebKey jwk)
         {
+            // Only write public JWK members — never emit private key material (d, p, q, dp, dq, qi, k, oth).
             writer.WriteStartObject();
             if (jwk.Kty is not null) writer.WriteString("kty", jwk.Kty);
             if (jwk.Crv is not null) writer.WriteString("crv", jwk.Crv);
             if (jwk.X is not null) writer.WriteString("x", jwk.X);
             if (jwk.Y is not null) writer.WriteString("y", jwk.Y);
-            if (jwk.D is not null) writer.WriteString("d", jwk.D);
             writer.WriteEndObject();
         }
     }

--- a/tests/NetDid.Core.Tests/Serialization/DidDocumentSerializerTests.cs
+++ b/tests/NetDid.Core.Tests/Serialization/DidDocumentSerializerTests.cs
@@ -357,4 +357,70 @@ public class DidDocumentSerializerTests
         restored.VerificationMethod![0].PublicKeyMultibase
             .Should().Be("z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
     }
+
+    // --- Security: private key stripping ---
+
+    [Fact]
+    public void Serialize_JwkWithPrivateKey_DoesNotEmitD()
+    {
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            VerificationMethod =
+            [
+                new VerificationMethod
+                {
+                    Id = "did:example:123#key-1",
+                    Type = "JsonWebKey2020",
+                    Controller = new Did("did:example:123"),
+                    PublicKeyJwk = new JsonWebKey
+                    {
+                        Kty = "OKP",
+                        Crv = "Ed25519",
+                        X = "public-x-value",
+                        D = "private-d-value"
+                    }
+                }
+            ]
+        };
+
+        var json = DidDocumentSerializer.Serialize(doc, DidContentTypes.Json);
+
+        json.Should().Contain("\"x\":\"public-x-value\"");
+        json.Should().NotContain("\"d\":");
+        json.Should().NotContain("private-d-value");
+    }
+
+    [Fact]
+    public void Serialize_JwkWithPrivateKey_RoundTripsPublicOnly()
+    {
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            VerificationMethod =
+            [
+                new VerificationMethod
+                {
+                    Id = "did:example:123#key-1",
+                    Type = "JsonWebKey2020",
+                    Controller = new Did("did:example:123"),
+                    PublicKeyJwk = new JsonWebKey
+                    {
+                        Kty = "EC",
+                        Crv = "P-256",
+                        X = "public-x",
+                        Y = "public-y",
+                        D = "private-d"
+                    }
+                }
+            ]
+        };
+
+        var json = DidDocumentSerializer.Serialize(doc, DidContentTypes.Json);
+        var restored = DidDocumentSerializer.Deserialize(json, DidContentTypes.Json);
+
+        restored.VerificationMethod![0].PublicKeyJwk!.X.Should().Be("public-x");
+        restored.VerificationMethod[0].PublicKeyJwk!.Y.Should().Be("public-y");
+        restored.VerificationMethod[0].PublicKeyJwk!.D.Should().BeNull();
+    }
 }


### PR DESCRIPTION
## Summary
- Remove `d` (private key) emission from `WriteJwk` in `DidDocumentSerializer`
- `publicKeyJwk` now only contains public members: `kty`, `crv`, `x`, `y`
- Prevents accidental secret exfiltration via DID document serialization

## Test plan
- [x] All 268 tests pass (2 new security regression tests)
- [x] `Serialize_JwkWithPrivateKey_DoesNotEmitD` verifies `d` is stripped
- [x] `Serialize_JwkWithPrivateKey_RoundTripsPublicOnly` verifies round-trip drops private material

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)