### PR TITLE
Fix JSON-LD context objects dropped during serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DID parser validation**: `DidParser.IsValid` now enforces W3C DID Core ABNF — rejects DID URLs (fragments, queries, paths, parameters), spaces, and other illegal characters. The `Did` value object now truly guarantees syntactic validity.
 - **DID URL parameter parsing**: `DidParser.ParseDidUrl` now correctly parses DID parameters (`;param=value`), modeled via new `DidUrl.Parameters` property.
 - **Private JWK key leak**: `DidDocumentSerializer` no longer emits private key member `d` from `publicKeyJwk`. Only public JWK members (`kty`, `crv`, `x`, `y`) are serialized.
+- **JSON-LD context objects**: Object-valued `@context` entries now round-trip correctly through serialization and deserialization. Previously they were dropped or caused `JsonException`.
 
 ## [0.2.0] - 2026-03-08
 

--- a/src/NetDid.Core/Serialization/DidDocumentSerializer.cs
+++ b/src/NetDid.Core/Serialization/DidDocumentSerializer.cs
@@ -97,9 +97,9 @@ public static class DidDocumentSerializer
     {
         var contexts = new List<object> { "https://www.w3.org/ns/did/v1" };
 
-        if (doc.VerificationMethod is null) return contexts;
-
-        var vmTypes = doc.VerificationMethod.Select(vm => vm.Type).Distinct().ToHashSet();
+        var vmTypes = new HashSet<string>();
+        if (doc.VerificationMethod is not null)
+            vmTypes = doc.VerificationMethod.Select(vm => vm.Type).Distinct().ToHashSet();
 
         // Also check embedded VMs in relationships
         AddEmbeddedVmTypes(doc.Authentication, vmTypes);
@@ -115,14 +115,22 @@ public static class DidDocumentSerializer
         if (vmTypes.Any(t => t.StartsWith("EcdsaSecp256k1")))
             contexts.Add("https://w3id.org/security/suites/secp256k1-2019/v1");
 
-        // Append any additional context URIs from the document
+        // Append any additional context entries (strings or JSON objects) from the document
         if (doc.Context is not null)
         {
             foreach (var ctx in doc.Context)
             {
-                var ctxStr = ctx?.ToString();
-                if (ctxStr is not null && !contexts.Any(c => c.ToString() == ctxStr))
-                    contexts.Add(ctx!);
+                if (ctx is null) continue;
+                if (ctx is string ctxStr)
+                {
+                    if (!contexts.Any(c => c is string s && s == ctxStr))
+                        contexts.Add(ctxStr);
+                }
+                else
+                {
+                    // Object-valued contexts (JsonElement) — always add
+                    contexts.Add(ctx);
+                }
             }
         }
 
@@ -233,15 +241,22 @@ public static class DidDocumentSerializer
 
         private static void WriteContextArray(Utf8JsonWriter writer, List<object> contexts)
         {
-            if (contexts.Count == 1)
+            if (contexts.Count == 1 && contexts[0] is string singleStr)
             {
-                writer.WriteStringValue(contexts[0].ToString());
+                writer.WriteStringValue(singleStr);
                 return;
             }
 
             writer.WriteStartArray();
             foreach (var ctx in contexts)
-                writer.WriteStringValue(ctx.ToString());
+            {
+                if (ctx is string str)
+                    writer.WriteStringValue(str);
+                else if (ctx is JsonElement element)
+                    element.WriteTo(writer);
+                else
+                    writer.WriteStringValue(ctx.ToString());
+            }
             writer.WriteEndArray();
         }
 
@@ -467,7 +482,15 @@ public static class DidDocumentSerializer
                 if (ctxProp.ValueKind == JsonValueKind.String)
                     context.Add(ctxProp.GetString()!);
                 else if (ctxProp.ValueKind == JsonValueKind.Array)
-                    context.AddRange(ctxProp.EnumerateArray().Select(e => (object)e.GetString()!));
+                {
+                    foreach (var elem in ctxProp.EnumerateArray())
+                    {
+                        if (elem.ValueKind == JsonValueKind.String)
+                            context.Add(elem.GetString()!);
+                        else
+                            context.Add(elem.Clone());
+                    }
+                }
             }
 
             List<string>? alsoKnownAs = null;

--- a/tests/NetDid.Core.Tests/Serialization/DidDocumentSerializerTests.cs
+++ b/tests/NetDid.Core.Tests/Serialization/DidDocumentSerializerTests.cs
@@ -423,4 +423,53 @@ public class DidDocumentSerializerTests
         restored.VerificationMethod[0].PublicKeyJwk!.Y.Should().Be("public-y");
         restored.VerificationMethod[0].PublicKeyJwk!.D.Should().BeNull();
     }
+
+    // --- JSON-LD context objects ---
+
+    [Fact]
+    public void Deserialize_ObjectValuedContext_DoesNotThrow()
+    {
+        var json = """
+        {
+          "@context": [
+            "https://www.w3.org/ns/did/v1",
+            { "example": "https://example.com/ns#" }
+          ],
+          "id": "did:example:123"
+        }
+        """;
+
+        var doc = DidDocumentSerializer.Deserialize(json, DidContentTypes.JsonLd);
+
+        doc.Id.Value.Should().Be("did:example:123");
+        doc.Context.Should().HaveCount(2);
+        doc.Context![0].Should().Be("https://www.w3.org/ns/did/v1");
+        doc.Context[1].Should().BeOfType<JsonElement>();
+    }
+
+    [Fact]
+    public void Serialize_ObjectValuedContext_RoundTrips()
+    {
+        var objContext = JsonDocument.Parse("""{"example":"https://example.com/ns#"}""").RootElement.Clone();
+
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            Context =
+            [
+                "https://www.w3.org/ns/did/v1",
+                objContext
+            ]
+        };
+
+        var json = DidDocumentSerializer.Serialize(doc, DidContentTypes.JsonLd);
+        json.Should().Contain("\"example\":\"https://example.com/ns#\"");
+
+        var restored = DidDocumentSerializer.Deserialize(json, DidContentTypes.JsonLd);
+        restored.Context.Should().HaveCount(2);
+        restored.Context![0].Should().Be("https://www.w3.org/ns/did/v1");
+
+        var restoredObj = (JsonElement)restored.Context[1];
+        restoredObj.GetProperty("example").GetString().Should().Be("https://example.com/ns#");
+    }
 }


### PR DESCRIPTION
## Summary
- Object-valued `@context` entries now serialize as JSON objects (not stringified via `.ToString()`)
- Deserialization handles both string and object entries via `JsonElement.Clone()`
- Fixed early return in `ComputeContext` that skipped user-provided contexts when no VMs existed
- Context dedup logic updated to handle mixed string/object entries

## Test plan
- [x] All 270 tests pass (2 new regression tests for context objects)
- [x] `Deserialize_ObjectValuedContext_DoesNotThrow` — parses mixed string/object context array
- [x] `Serialize_ObjectValuedContext_RoundTrips` — object contexts survive serialization round-trip

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)