### PR TITLE
Fix dereferencer for embedded verification methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DID URL parameter parsing**: `DidParser.ParseDidUrl` now correctly parses DID parameters (`;param=value`), modeled via new `DidUrl.Parameters` property.
 - **Private JWK key leak**: `DidDocumentSerializer` no longer emits private key member `d` from `publicKeyJwk`. Only public JWK members (`kty`, `crv`, `x`, `y`) are serialized.
 - **JSON-LD context objects**: Object-valued `@context` entries now round-trip correctly through serialization and deserialization. Previously they were dropped or caused `JsonException`.
+- **Embedded VM dereferencing**: `DefaultDidUrlDereferencer` now finds embedded verification methods inside all relationship arrays (`authentication`, `assertionMethod`, `keyAgreement`, `capabilityInvocation`, `capabilityDelegation`) when resolving by fragment.
 
 ## [0.2.0] - 2026-03-08
 

--- a/src/NetDid.Core/Resolution/DefaultDidUrlDereferencer.cs
+++ b/src/NetDid.Core/Resolution/DefaultDidUrlDereferencer.cs
@@ -104,17 +104,20 @@ public sealed class DefaultDidUrlDereferencer : IDidUrlDereferencer
 
     private static object? FindByFragment(DidDocument doc, string fragment)
     {
-        // Search verification methods
+        // Search top-level verification methods
         if (doc.VerificationMethod is not null)
         {
-            var vm = doc.VerificationMethod.FirstOrDefault(v =>
-            {
-                var hashIndex = v.Id.IndexOf('#');
-                var vmFragment = hashIndex >= 0 ? v.Id[(hashIndex + 1)..] : v.Id;
-                return vmFragment == fragment;
-            });
+            var vm = FindVmByFragment(doc.VerificationMethod, fragment);
             if (vm is not null) return vm;
         }
+
+        // Search embedded verification methods in all relationship arrays
+        var embedded = FindEmbeddedVmByFragment(doc.Authentication, fragment)
+            ?? FindEmbeddedVmByFragment(doc.AssertionMethod, fragment)
+            ?? FindEmbeddedVmByFragment(doc.KeyAgreement, fragment)
+            ?? FindEmbeddedVmByFragment(doc.CapabilityInvocation, fragment)
+            ?? FindEmbeddedVmByFragment(doc.CapabilityDelegation, fragment);
+        if (embedded is not null) return embedded;
 
         // Search services
         if (doc.Service is not null)
@@ -128,6 +131,33 @@ public sealed class DefaultDidUrlDereferencer : IDidUrlDereferencer
             if (svc is not null) return svc;
         }
 
+        return null;
+    }
+
+    private static VerificationMethod? FindVmByFragment(
+        IReadOnlyList<VerificationMethod> methods, string fragment)
+    {
+        return methods.FirstOrDefault(v =>
+        {
+            var hashIndex = v.Id.IndexOf('#');
+            var vmFragment = hashIndex >= 0 ? v.Id[(hashIndex + 1)..] : v.Id;
+            return vmFragment == fragment;
+        });
+    }
+
+    private static VerificationMethod? FindEmbeddedVmByFragment(
+        IReadOnlyList<VerificationRelationshipEntry>? entries, string fragment)
+    {
+        if (entries is null) return null;
+        foreach (var entry in entries)
+        {
+            if (!entry.IsReference && entry.EmbeddedMethod is not null)
+            {
+                var hashIndex = entry.EmbeddedMethod.Id.IndexOf('#');
+                var vmFragment = hashIndex >= 0 ? entry.EmbeddedMethod.Id[(hashIndex + 1)..] : entry.EmbeddedMethod.Id;
+                if (vmFragment == fragment) return entry.EmbeddedMethod;
+            }
+        }
         return null;
     }
 

--- a/tests/NetDid.Core.Tests/Resolution/DefaultDidUrlDereferencerTests.cs
+++ b/tests/NetDid.Core.Tests/Resolution/DefaultDidUrlDereferencerTests.cs
@@ -171,4 +171,132 @@ public class DefaultDidUrlDereferencerTests
 
         result.DereferencingMetadata.Error.Should().Be("notFound");
     }
+
+    // --- Embedded verification method dereferencing ---
+
+    [Fact]
+    public async Task DereferenceAsync_EmbeddedVm_InAuthentication_ReturnsVm()
+    {
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            Authentication =
+            [
+                VerificationRelationshipEntry.FromEmbedded(new VerificationMethod
+                {
+                    Id = "did:example:123#embedded-auth",
+                    Type = "Multikey",
+                    Controller = new Did("did:example:123"),
+                    PublicKeyMultibase = "z6Mkexample"
+                })
+            ]
+        };
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync("did:example:123#embedded-auth");
+
+        result.DereferencingMetadata.Error.Should().BeNull();
+        result.ContentStream.Should().BeOfType<VerificationMethod>();
+        ((VerificationMethod)result.ContentStream!).Id.Should().Be("did:example:123#embedded-auth");
+    }
+
+    [Fact]
+    public async Task DereferenceAsync_EmbeddedVm_InKeyAgreement_ReturnsVm()
+    {
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            KeyAgreement =
+            [
+                VerificationRelationshipEntry.FromEmbedded(new VerificationMethod
+                {
+                    Id = "did:example:123#embedded-agree",
+                    Type = "Multikey",
+                    Controller = new Did("did:example:123"),
+                    PublicKeyMultibase = "z6LSexample"
+                })
+            ]
+        };
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync("did:example:123#embedded-agree");
+
+        result.DereferencingMetadata.Error.Should().BeNull();
+        result.ContentStream.Should().BeOfType<VerificationMethod>();
+    }
+
+    [Fact]
+    public async Task DereferenceAsync_EmbeddedVm_InAssertionMethod_ReturnsVm()
+    {
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            AssertionMethod =
+            [
+                VerificationRelationshipEntry.FromEmbedded(new VerificationMethod
+                {
+                    Id = "did:example:123#embedded-assert",
+                    Type = "Multikey",
+                    Controller = new Did("did:example:123"),
+                    PublicKeyMultibase = "z6Mkexample"
+                })
+            ]
+        };
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync("did:example:123#embedded-assert");
+
+        result.DereferencingMetadata.Error.Should().BeNull();
+        result.ContentStream.Should().BeOfType<VerificationMethod>();
+    }
+
+    [Fact]
+    public async Task DereferenceAsync_EmbeddedVm_InCapabilityInvocation_ReturnsVm()
+    {
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            CapabilityInvocation =
+            [
+                VerificationRelationshipEntry.FromEmbedded(new VerificationMethod
+                {
+                    Id = "did:example:123#embedded-invoke",
+                    Type = "Multikey",
+                    Controller = new Did("did:example:123"),
+                    PublicKeyMultibase = "z6Mkexample"
+                })
+            ]
+        };
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync("did:example:123#embedded-invoke");
+
+        result.DereferencingMetadata.Error.Should().BeNull();
+        result.ContentStream.Should().BeOfType<VerificationMethod>();
+    }
+
+    [Fact]
+    public async Task DereferenceAsync_EmbeddedVm_InCapabilityDelegation_ReturnsVm()
+    {
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            CapabilityDelegation =
+            [
+                VerificationRelationshipEntry.FromEmbedded(new VerificationMethod
+                {
+                    Id = "did:example:123#embedded-delegate",
+                    Type = "Multikey",
+                    Controller = new Did("did:example:123"),
+                    PublicKeyMultibase = "z6Mkexample"
+                })
+            ]
+        };
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync("did:example:123#embedded-delegate");
+
+        result.DereferencingMetadata.Error.Should().BeNull();
+        result.ContentStream.Should().BeOfType<VerificationMethod>();
+    }
 }


### PR DESCRIPTION
## Summary
- `FindByFragment` now searches embedded verification methods in all five relationship arrays (`authentication`, `assertionMethod`, `keyAgreement`, `capabilityInvocation`, `capabilityDelegation`)
- Extracted `FindVmByFragment` and `FindEmbeddedVmByFragment` helpers to reduce duplication

## Test plan
- [x] All 275 tests pass (5 new tests for embedded VMs in each relationship type)
- [x] Fragment dereference works for embedded VMs in authentication, keyAgreement, assertionMethod, capabilityInvocation, capabilityDelegation

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)