### PR TITLE
Fix did:peer numalgo 4 resolution fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **JSON-LD context objects**: Object-valued `@context` entries now round-trip correctly through serialization and deserialization. Previously they were dropped or caused `JsonException`.
 - **Embedded VM dereferencing**: `DefaultDidUrlDereferencer` now finds embedded verification methods inside all relationship arrays (`authentication`, `assertionMethod`, `keyAgreement`, `capabilityInvocation`, `capabilityDelegation`) when resolving by fragment.
 - **Documentation alignment**: Aligned `CLAUDE.md`, `AGENTS.md`, and `NetDidPRD.md` with actual implementation status. Only `did:key` and `did:peer` are implemented; `did:webvh` and `did:ethr` are marked as planned. W3C Test Suite conformance claims downgraded to planned.
+- **did:peer numalgo 4 resolution fidelity**: `BuildResolvedDocument` now rewrites controller values matching the placeholder DID, rewrites embedded verification methods in relationship arrays, and preserves `@context` and `AdditionalProperties`. Input document now serialized as JSON-LD so `@context` survives round-trip.
 
 ## [0.2.0] - 2026-03-08
 

--- a/src/NetDid.Method.Peer/Numalgo4Handler.cs
+++ b/src/NetDid.Method.Peer/Numalgo4Handler.cs
@@ -19,8 +19,8 @@ internal sealed class Numalgo4Handler
         if (options.InputDocument is null)
             throw new ArgumentException("Numalgo 4 requires InputDocument.");
 
-        // Serialize the input document to JSON
-        var json = DidDocumentSerializer.Serialize(options.InputDocument, DidContentTypes.Json);
+        // Serialize as JSON-LD so @context is included in the encoded document
+        var json = DidDocumentSerializer.Serialize(options.InputDocument, DidContentTypes.JsonLd);
         var docBytes = Encoding.UTF8.GetBytes(json);
 
         // Compute SHA-256 hash, multicodec-prefix with SHA-256 code (0x12), then multibase-encode
@@ -106,28 +106,26 @@ internal sealed class Numalgo4Handler
     private static DidDocument BuildResolvedDocument(string did, DidDocument inputDoc)
     {
         var didValue = new Did(did);
+        var originalDid = inputDoc.Id.Value;
 
         // Replace the id with the actual DID and prefix relative references
-        var verificationMethods = inputDoc.VerificationMethod?.Select(vm => new VerificationMethod
-        {
-            Id = PrefixId(vm.Id, did),
-            Type = vm.Type,
-            Controller = vm.Controller.Value == inputDoc.Id.Value ? didValue : vm.Controller,
-            PublicKeyMultibase = vm.PublicKeyMultibase,
-            PublicKeyJwk = vm.PublicKeyJwk,
-            BlockchainAccountId = vm.BlockchainAccountId
-        }).ToList();
+        var verificationMethods = inputDoc.VerificationMethod?.Select(vm =>
+            RewriteVerificationMethod(vm, did, didValue, originalDid)).ToList();
+
+        // Rewrite controller references
+        var controller = inputDoc.Controller?.Select(c =>
+            c.Value == originalDid ? didValue : c).ToList();
 
         return new DidDocument
         {
             Id = didValue,
-            Controller = inputDoc.Controller,
+            Controller = controller,
             VerificationMethod = verificationMethods,
-            Authentication = PrefixRelationships(inputDoc.Authentication, did, inputDoc.Id.Value),
-            AssertionMethod = PrefixRelationships(inputDoc.AssertionMethod, did, inputDoc.Id.Value),
-            KeyAgreement = PrefixRelationships(inputDoc.KeyAgreement, did, inputDoc.Id.Value),
-            CapabilityInvocation = PrefixRelationships(inputDoc.CapabilityInvocation, did, inputDoc.Id.Value),
-            CapabilityDelegation = PrefixRelationships(inputDoc.CapabilityDelegation, did, inputDoc.Id.Value),
+            Authentication = RewriteRelationships(inputDoc.Authentication, did, didValue, originalDid),
+            AssertionMethod = RewriteRelationships(inputDoc.AssertionMethod, did, didValue, originalDid),
+            KeyAgreement = RewriteRelationships(inputDoc.KeyAgreement, did, didValue, originalDid),
+            CapabilityInvocation = RewriteRelationships(inputDoc.CapabilityInvocation, did, didValue, originalDid),
+            CapabilityDelegation = RewriteRelationships(inputDoc.CapabilityDelegation, did, didValue, originalDid),
             Service = inputDoc.Service?.Select((svc, i) => new Service
             {
                 Id = PrefixId(svc.Id, did),
@@ -135,7 +133,23 @@ internal sealed class Numalgo4Handler
                 ServiceEndpoint = svc.ServiceEndpoint,
                 AdditionalProperties = svc.AdditionalProperties
             }).ToList(),
-            AlsoKnownAs = inputDoc.AlsoKnownAs
+            AlsoKnownAs = inputDoc.AlsoKnownAs,
+            Context = inputDoc.Context,
+            AdditionalProperties = inputDoc.AdditionalProperties
+        };
+    }
+
+    private static VerificationMethod RewriteVerificationMethod(
+        VerificationMethod vm, string did, Did didValue, string originalDid)
+    {
+        return new VerificationMethod
+        {
+            Id = PrefixId(vm.Id, did),
+            Type = vm.Type,
+            Controller = vm.Controller.Value == originalDid ? didValue : vm.Controller,
+            PublicKeyMultibase = vm.PublicKeyMultibase,
+            PublicKeyJwk = vm.PublicKeyJwk,
+            BlockchainAccountId = vm.BlockchainAccountId
         };
     }
 
@@ -147,8 +161,8 @@ internal sealed class Numalgo4Handler
         return id;
     }
 
-    private static List<VerificationRelationshipEntry>? PrefixRelationships(
-        IReadOnlyList<VerificationRelationshipEntry>? entries, string did, string originalDid)
+    private static List<VerificationRelationshipEntry>? RewriteRelationships(
+        IReadOnlyList<VerificationRelationshipEntry>? entries, string did, Did didValue, string originalDid)
     {
         if (entries is null) return null;
 
@@ -162,6 +176,13 @@ internal sealed class Numalgo4Handler
                 else if (reference.StartsWith(originalDid))
                     reference = did + reference[originalDid.Length..];
                 return VerificationRelationshipEntry.FromReference(reference);
+            }
+
+            // Embedded verification method — rewrite it too
+            if (entry.EmbeddedMethod is not null)
+            {
+                var rewritten = RewriteVerificationMethod(entry.EmbeddedMethod, did, didValue, originalDid);
+                return VerificationRelationshipEntry.FromEmbedded(rewritten);
             }
 
             return entry;

--- a/tests/NetDid.Method.Peer.Tests/DidPeerMethodTests.cs
+++ b/tests/NetDid.Method.Peer.Tests/DidPeerMethodTests.cs
@@ -369,6 +369,204 @@ public class DidPeerMethodTests
     }
 
     [Fact]
+    public async Task Numalgo4_ControllerRewritten()
+    {
+        var keyPair = _keyGen.Generate(KeyType.Ed25519);
+
+        var inputDoc = new DidDocument
+        {
+            Id = new Did("did:peer:placeholder"),
+            Controller = [new Did("did:peer:placeholder")],
+            VerificationMethod =
+            [
+                new VerificationMethod
+                {
+                    Id = "#key-0",
+                    Type = "Multikey",
+                    Controller = new Did("did:peer:placeholder"),
+                    PublicKeyMultibase = keyPair.MultibasePublicKey
+                }
+            ],
+            Authentication =
+            [
+                VerificationRelationshipEntry.FromReference("#key-0")
+            ]
+        };
+
+        var result = await _method.CreateAsync(new DidPeerCreateOptions
+        {
+            Numalgo = PeerNumalgo.Four,
+            InputDocument = inputDoc
+        });
+
+        // Controller should be rewritten to actual DID
+        result.DidDocument.Controller.Should().HaveCount(1);
+        result.DidDocument.Controller![0].Value.Should().Be(result.Did.Value);
+        result.DidDocument.Controller[0].Value.Should().NotBe("did:peer:placeholder");
+
+        // VM controller also rewritten
+        result.DidDocument.VerificationMethod![0].Controller.Value.Should().Be(result.Did.Value);
+
+        // Resolve round-trip
+        var resolved = await _method.ResolveAsync(result.Did.Value);
+        resolved.DidDocument!.Controller.Should().HaveCount(1);
+        resolved.DidDocument.Controller![0].Value.Should().Be(result.Did.Value);
+        resolved.DidDocument.VerificationMethod![0].Controller.Value.Should().Be(result.Did.Value);
+    }
+
+    [Fact]
+    public async Task Numalgo4_EmbeddedVerificationMethod_Rewritten()
+    {
+        var keyPair = _keyGen.Generate(KeyType.Ed25519);
+
+        var inputDoc = new DidDocument
+        {
+            Id = new Did("did:peer:placeholder"),
+            Authentication =
+            [
+                VerificationRelationshipEntry.FromEmbedded(new VerificationMethod
+                {
+                    Id = "#embedded-key",
+                    Type = "Multikey",
+                    Controller = new Did("did:peer:placeholder"),
+                    PublicKeyMultibase = keyPair.MultibasePublicKey
+                })
+            ]
+        };
+
+        var result = await _method.CreateAsync(new DidPeerCreateOptions
+        {
+            Numalgo = PeerNumalgo.Four,
+            InputDocument = inputDoc
+        });
+
+        var embeddedVm = result.DidDocument.Authentication![0].EmbeddedMethod!;
+        embeddedVm.Id.Should().Be(result.Did.Value + "#embedded-key");
+        embeddedVm.Controller.Value.Should().Be(result.Did.Value);
+
+        // Resolve round-trip
+        var resolved = await _method.ResolveAsync(result.Did.Value);
+        var resolvedVm = resolved.DidDocument!.Authentication![0].EmbeddedMethod!;
+        resolvedVm.Id.Should().Be(result.Did.Value + "#embedded-key");
+        resolvedVm.Controller.Value.Should().Be(result.Did.Value);
+    }
+
+    [Fact]
+    public async Task Numalgo4_ContextPreserved()
+    {
+        var keyPair = _keyGen.Generate(KeyType.Ed25519);
+
+        var inputDoc = new DidDocument
+        {
+            Id = new Did("did:peer:placeholder"),
+            Context = ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/multikey/v1"],
+            VerificationMethod =
+            [
+                new VerificationMethod
+                {
+                    Id = "#key-0",
+                    Type = "Multikey",
+                    Controller = new Did("did:peer:placeholder"),
+                    PublicKeyMultibase = keyPair.MultibasePublicKey
+                }
+            ]
+        };
+
+        var result = await _method.CreateAsync(new DidPeerCreateOptions
+        {
+            Numalgo = PeerNumalgo.Four,
+            InputDocument = inputDoc
+        });
+
+        result.DidDocument.Context.Should().HaveCount(2);
+
+        var resolved = await _method.ResolveAsync(result.Did.Value);
+        resolved.DidDocument!.Context.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Numalgo4_AdditionalPropertiesPreserved()
+    {
+        var keyPair = _keyGen.Generate(KeyType.Ed25519);
+        var customElement = System.Text.Json.JsonDocument.Parse("\"custom-value\"").RootElement.Clone();
+
+        var inputDoc = new DidDocument
+        {
+            Id = new Did("did:peer:placeholder"),
+            VerificationMethod =
+            [
+                new VerificationMethod
+                {
+                    Id = "#key-0",
+                    Type = "Multikey",
+                    Controller = new Did("did:peer:placeholder"),
+                    PublicKeyMultibase = keyPair.MultibasePublicKey
+                }
+            ],
+            AdditionalProperties = new Dictionary<string, System.Text.Json.JsonElement>
+            {
+                ["customProp"] = customElement
+            }
+        };
+
+        var result = await _method.CreateAsync(new DidPeerCreateOptions
+        {
+            Numalgo = PeerNumalgo.Four,
+            InputDocument = inputDoc
+        });
+
+        result.DidDocument.AdditionalProperties.Should().ContainKey("customProp");
+
+        var resolved = await _method.ResolveAsync(result.Did.Value);
+        resolved.DidDocument!.AdditionalProperties.Should().ContainKey("customProp");
+        resolved.DidDocument.AdditionalProperties!["customProp"].GetString().Should().Be("custom-value");
+    }
+
+    [Fact]
+    public async Task Numalgo4_ServiceIdRewritten()
+    {
+        var keyPair = _keyGen.Generate(KeyType.Ed25519);
+
+        var inputDoc = new DidDocument
+        {
+            Id = new Did("did:peer:placeholder"),
+            VerificationMethod =
+            [
+                new VerificationMethod
+                {
+                    Id = "#key-0",
+                    Type = "Multikey",
+                    Controller = new Did("did:peer:placeholder"),
+                    PublicKeyMultibase = keyPair.MultibasePublicKey
+                }
+            ],
+            Service =
+            [
+                new Service
+                {
+                    Id = "#svc-0",
+                    Type = "DIDCommMessaging",
+                    ServiceEndpoint = ServiceEndpointValue.FromUri("https://example.com/endpoint")
+                }
+            ]
+        };
+
+        var result = await _method.CreateAsync(new DidPeerCreateOptions
+        {
+            Numalgo = PeerNumalgo.Four,
+            InputDocument = inputDoc
+        });
+
+        result.DidDocument.Service.Should().HaveCount(1);
+        result.DidDocument.Service![0].Id.Should().Be(result.Did.Value + "#svc-0");
+
+        var resolved = await _method.ResolveAsync(result.Did.Value);
+        resolved.DidDocument!.Service.Should().HaveCount(1);
+        resolved.DidDocument.Service![0].Id.Should().Be(result.Did.Value + "#svc-0");
+        resolved.DidDocument.Service[0].ServiceEndpoint.Uri.Should().Be("https://example.com/endpoint");
+    }
+
+    [Fact]
     public async Task Numalgo4_TamperedLongForm_ReturnsNotFound()
     {
         var keyPair = _keyGen.Generate(KeyType.Ed25519);


### PR DESCRIPTION
## Summary

- Rewrite `Controller` values matching the placeholder DID to the actual resolved DID
- Rewrite embedded verification methods inside relationship arrays (not just references)
- Preserve `@context` by serializing input document as JSON-LD (was `application/did+json`)
- Preserve `AdditionalProperties` in the resolved document
- Add 5 regression tests: controller rewriting, embedded VM rewriting, context preservation, additional properties preservation, service ID rewriting

Closes #7

## Test plan

- [x] All 280 tests pass (233 core + 25 peer + 22 key)
- [x] New tests verify each of the 4 fixed behaviors round-trips through create → resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)