### PR TITLE
Fix #29: representationNotSupported and service ID normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-03-15
+
+### Fixed
+
+- **Service dereferencing: unsupported Accept** (#29): Unsupported `Accept` media types (e.g. `text/plain`) now return `representationNotSupported` instead of incorrectly returning a DID Document. Only `application/did+ld+json`, `application/did+json`, and `text/uri-list` are accepted.
+- **Service dereferencing: ID normalization** (#29): Service ID matching now normalizes relative and absolute URIs before comparison. A service with `id: "#svc"` correctly matches a query `?service=did:example:123%23svc`, and vice versa.
+
 ## [1.1.0] - 2026-03-15
 
 ### Added
@@ -25,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Invalid DID misclassification** (#26): `DidManager` and `CompositeDidResolver` now return `invalidDid` for syntactically invalid DIDs instead of incorrectly returning `methodNotSupported`. Validation via `DidParser.IsValid` runs before method extraction.
-- **Service dereferencing algorithm** (#29): `DefaultDidUrlDereferencer` now returns a DID Document wrapper for service queries when `Accept` is not `text/uri-list` (previously returned the raw `Service` object). Service selection by `?service=` now matches both full DID URL IDs and fragment-only IDs. Endpoint sets (`ServiceEndpointValue.IsSet`) are handled for `text/uri-list` responses. URL construction uses `System.Uri` for RFC 3986 compliance.
+- **Service dereferencing algorithm** (#29): `DefaultDidUrlDereferencer` now returns a DID Document wrapper for service queries when `Accept` is a DID document content type (previously returned the raw `Service` object). Unsupported `Accept` values return `representationNotSupported`. Service ID matching normalizes relative and absolute URIs before comparison (e.g. `#svc` matches `did:example:123#svc`). Endpoint sets (`ServiceEndpointValue.IsSet`) are handled for `text/uri-list` responses. URL construction uses `System.Uri` for RFC 3986 compliance.
 - **Witness validation spec compliance** (#15): Witness validation now checks all witnessed versions in the log chain, not just the final entry. Cumulative coverage rule implemented: a witness proof at version N satisfies all versions ≤ N, with deduplication by witness ID. Legacy single-object `did-witness.json` format is now rejected (only spec-compliant JSON array format accepted). Missing or malformed witness files correctly fail resolution when witness threshold > 0.
 - **did:peer:4 long-form encoding** (#25): Encoding now follows the current peer-DID spec — contextualizes the input document, prepends JSON multicodec, multibase-encodes the result, and computes the short-form hash from the encoded document.
 - **EC key encodings** (#27): `did:key` and `did:peer:0` now use compressed point encoding for P-256, P-384, and secp256k1 keys per the `did:key` specification. Malformed multicodec payloads are rejected during resolution instead of producing unusable verification methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Service dereferencing: unsupported Accept** (#29): Unsupported `Accept` media types (e.g. `text/plain`) now return `representationNotSupported` instead of incorrectly returning a DID Document. Only `application/did+ld+json`, `application/did+json`, and `text/uri-list` are accepted.
 - **Service dereferencing: ID normalization** (#29): Service ID matching now normalizes relative and absolute URIs before comparison. A service with `id: "#svc"` correctly matches a query `?service=did:example:123%23svc`, and vice versa.
+- **Service dereferencing: serviceType URI list** (#29): `?serviceType=<type>` with `Accept: text/uri-list` now returns URLs from all matching services, not just the first one.
+- **Service dereferencing: fragment guard** (#29): `ConstructServiceUrl` no longer appends a DID URL fragment when the service endpoint URI already contains its own fragment.
 
 ## [1.1.0] - 2026-03-15
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NetDidVersion>1.1.0</NetDidVersion>
+    <NetDidVersion>1.1.1</NetDidVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -480,11 +480,11 @@ netdid/
 │   ├── NetDid.Method.WebVh/                 # did:webvh method (full CRUD)
 │   └── NetDid.Extensions.DependencyInjection/  # Microsoft DI integration
 ├── tests/
-│   ├── NetDid.Core.Tests/                   # 292 unit tests
+│   ├── NetDid.Core.Tests/                   # 302 unit tests
 │   ├── NetDid.Method.Key.Tests/             # 28 tests
 │   ├── NetDid.Method.Peer.Tests/            # 31 tests
 │   ├── NetDid.Method.WebVh.Tests/           # 70 tests
-│   ├── NetDid.Tests.W3CConformance/         # 173 W3C conformance tests
+│   ├── NetDid.Tests.W3CConformance/         # 175 W3C conformance tests
 │   └── NetDid.Extensions.DependencyInjection.Tests/  # 10 tests
 ├── samples/
 │   ├── NetDid.Samples.DidKey/               # did:key usage examples

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ netdid/
 │   ├── NetDid.Method.WebVh/                 # did:webvh method (full CRUD)
 │   └── NetDid.Extensions.DependencyInjection/  # Microsoft DI integration
 ├── tests/
-│   ├── NetDid.Core.Tests/                   # 302 unit tests
+│   ├── NetDid.Core.Tests/                   # 305 unit tests
 │   ├── NetDid.Method.Key.Tests/             # 28 tests
 │   ├── NetDid.Method.Peer.Tests/            # 31 tests
 │   ├── NetDid.Method.WebVh.Tests/           # 70 tests

--- a/README.md
+++ b/README.md
@@ -526,6 +526,10 @@ NetDid is developed in four phases (see [NetDidPRD.md](NetDidPRD.md) for full de
 | **III** | `did:webvh` method implementation | Complete |
 | **IV** | `did:ethr` method implementation | Planned |
 
+## W3C Conformance
+
+See [w3c-conformance-report.md](w3c-conformance-report.md) for the full W3C DID Core conformance report across all implemented methods.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, code conventions, and how to add new DID methods or key types.

--- a/src/NetDid.Core/Resolution/DefaultDidUrlDereferencer.cs
+++ b/src/NetDid.Core/Resolution/DefaultDidUrlDereferencer.cs
@@ -55,14 +55,28 @@ public sealed class DefaultDidUrlDereferencer : IDidUrlDereferencer
             if (matchingServices.Count == 0)
                 return DidUrlDereferencingResult.Error("notFound");
 
-            // For text/uri-list, redirect to the first URI-type or set endpoint
+            // For text/uri-list, collect redirect URLs from ALL matching services
             if (accept == "text/uri-list")
             {
-                var redirectable = matchingServices.FirstOrDefault(s =>
-                    s.ServiceEndpoint.IsUri || s.ServiceEndpoint.IsSet);
-                if (redirectable is null)
+                var path = parsed.Path;
+                var relativeRef = queryParams.GetValueOrDefault("relativeRef");
+                var fragment = parsed.Fragment;
+                var allUris = new List<string>();
+
+                foreach (var svc in matchingServices)
+                {
+                    if (svc.ServiceEndpoint.IsUri)
+                        allUris.Add(ConstructServiceUrl(svc.ServiceEndpoint, path, relativeRef, fragment));
+                    else if (svc.ServiceEndpoint.IsSet)
+                        allUris.AddRange(svc.ServiceEndpoint.Set!
+                            .Where(ep => ep.IsUri)
+                            .Select(ep => ConstructServiceUrl(ep, path, relativeRef, fragment)));
+                }
+
+                if (allUris.Count == 0)
                     return DidUrlDereferencingResult.Error("notFound");
-                return BuildServiceResult(redirectable, doc, parsed, queryParams, accept);
+                return DidUrlDereferencingResult.ServiceEndpointRedirect(
+                    string.Join("\r\n", allUris));
             }
 
             // Only DID document content types are valid for non-redirect results
@@ -294,6 +308,8 @@ public sealed class DefaultDidUrlDereferencer : IDidUrlDereferencer
 
     /// <summary>
     /// Construct a service endpoint URL using RFC 3986 reference resolution.
+    /// If the service endpoint URI already contains a fragment, the DID URL
+    /// fragment is not appended (the endpoint's own fragment takes precedence).
     /// </summary>
     private static string ConstructServiceUrl(
         ServiceEndpointValue endpoint, string? path, string? relativeRef, string? fragment)
@@ -306,7 +322,9 @@ public sealed class DefaultDidUrlDereferencer : IDidUrlDereferencer
             relative += path;
         if (relativeRef is not null)
             relative += relativeRef;
-        if (fragment is not null)
+
+        // Only append the DID URL fragment if the base URI does not already have one
+        if (fragment is not null && string.IsNullOrEmpty(baseUri.Fragment))
             relative += "#" + fragment;
 
         if (string.IsNullOrEmpty(relative))

--- a/src/NetDid.Core/Resolution/DefaultDidUrlDereferencer.cs
+++ b/src/NetDid.Core/Resolution/DefaultDidUrlDereferencer.cs
@@ -65,6 +65,10 @@ public sealed class DefaultDidUrlDereferencer : IDidUrlDereferencer
                 return BuildServiceResult(redirectable, doc, parsed, queryParams, accept);
             }
 
+            // Only DID document content types are valid for non-redirect results
+            if (!IsDidDocumentContentType(accept))
+                return DidUrlDereferencingResult.Error("representationNotSupported");
+
             // Return a DID Document containing the matched service(s)
             var filteredDoc = new DidDocument { Id = doc.Id, Service = matchingServices.ToList() };
             return DidUrlDereferencingResult.Success(filteredDoc, accept);
@@ -123,7 +127,11 @@ public sealed class DefaultDidUrlDereferencer : IDidUrlDereferencer
             return DidUrlDereferencingResult.Error("notFound");
         }
 
-        // Default: return a DID Document containing the selected service
+        // Only DID document content types are valid for non-redirect results
+        if (!IsDidDocumentContentType(accept))
+            return DidUrlDereferencingResult.Error("representationNotSupported");
+
+        // Return a DID Document containing the selected service
         var filteredDoc = new DidDocument { Id = doc.Id, Service = [service] };
         return DidUrlDereferencingResult.Success(filteredDoc, accept);
     }
@@ -150,15 +158,31 @@ public sealed class DefaultDidUrlDereferencer : IDidUrlDereferencer
     {
         if (doc.Service is null) return null;
 
+        // Normalize the query value to an absolute URI using the document's id
+        var normalizedQuery = NormalizeServiceId(serviceId, doc.Id);
+
         return doc.Service.FirstOrDefault(s =>
         {
-            // Match against full service ID or fragment portion
-            if (s.Id == serviceId) return true;
-            var hashIndex = s.Id.IndexOf('#');
-            var fragment = hashIndex >= 0 ? s.Id[(hashIndex + 1)..] : s.Id;
-            return fragment == serviceId;
+            var normalizedSvcId = NormalizeServiceId(s.Id, doc.Id);
+            return normalizedSvcId == normalizedQuery;
         });
     }
+
+    /// <summary>
+    /// Resolves a service ID to an absolute URI. Relative references like "#svc"
+    /// are resolved against the DID base, producing "did:example:123#svc".
+    /// </summary>
+    private static string NormalizeServiceId(string id, string did)
+    {
+        if (id.StartsWith('#'))
+            return did + id;
+        if (!id.Contains(':'))
+            return did + "#" + id;
+        return id;
+    }
+
+    private static bool IsDidDocumentContentType(string accept)
+        => accept is DidContentTypes.JsonLd or DidContentTypes.Json;
 
     private static IReadOnlyList<Service> FindServicesByType(DidDocument doc, string serviceType)
     {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,3 @@
+# Lessons
+
+- When the user corrects or narrows a request mid-thread, restate the corrected scope explicitly in the next work pass and revalidate only that scope before taking issue-tracker actions.

--- a/tasks/todo20260315-233707.md
+++ b/tasks/todo20260315-233707.md
@@ -1,0 +1,55 @@
+# Follow-up Review: Revalidate Issue #29
+
+## Context
+
+- Date: 2026-03-15
+- Scope: verify whether issue `#29` is now fully fixed
+- Focus:
+  - current implementation
+  - regression tests
+  - current GitHub issue state
+  - DID Resolution alignment
+
+## Checklist
+
+- [x] Create a dedicated revalidation note
+- [x] Inspect current implementation for issue `#29`
+- [x] Inspect relevant regression tests
+- [x] Check current GitHub issue state and recent discussion
+- [x] Compare current behavior against DID Resolution expectations
+- [x] Record final classification
+
+## Working Notes
+
+- Current issue state is still `OPEN`.
+- The previous blockers I raised are now fixed:
+  - unsupported `Accept` values now return `representationNotSupported`
+  - service id matching now normalizes relative and absolute ids before comparison
+  - there is direct regression coverage for both
+- Remaining gaps I still see:
+  - `serviceType` + `Accept: text/uri-list` only returns the first redirectable service, not all matching service endpoint URLs:
+    - `src/NetDid.Core/Resolution/DefaultDidUrlDereferencer.cs:58-65`
+  - service-endpoint fragment conflicts are still not checked before appending a DID URL fragment into the redirect URL:
+    - `src/NetDid.Core/Resolution/DefaultDidUrlDereferencer.cs:103-123`
+    - `src/NetDid.Core/Resolution/DefaultDidUrlDereferencer.cs:298-317`
+- Current tests cover:
+  - unsupported `Accept` handling
+  - relative/absolute service-id normalization
+  - URI set handling
+  - verificationRelationship filtering
+- Added coverage now exists for:
+  - multiple `serviceType` matches with `text/uri-list`
+  - service endpoint URIs that already contain a fragment component
+- Verification:
+  - `dotnet test tests/NetDid.Core.Tests/NetDid.Core.Tests.csproj --no-restore` -> `305 passed`
+
+## Findings
+
+- `#29` no longer looks broken based on the current code and tests.
+- The issue was closed after revalidation.
+
+## Action Taken
+
+- Posted the latest revalidation details to GitHub issue `#29`:
+  - `https://github.com/moisesja/net-did/issues/29#issuecomment-4064851132`
+- Closed GitHub issue `#29` with a final verification note after confirming the current implementation and test status.

--- a/tests/NetDid.Core.Tests/Resolution/DefaultDidUrlDereferencerTests.cs
+++ b/tests/NetDid.Core.Tests/Resolution/DefaultDidUrlDereferencerTests.cs
@@ -441,6 +441,138 @@ public class DefaultDidUrlDereferencerTests
         result.DereferencingMetadata.Error.Should().Be("notFound");
     }
 
+    // --- Unsupported Accept returns representationNotSupported ---
+
+    [Theory]
+    [InlineData("text/plain")]
+    [InlineData("application/xml")]
+    [InlineData("text/html")]
+    public async Task DereferenceAsync_ServiceQuery_UnsupportedAccept_ReturnsRepresentationNotSupported(string accept)
+    {
+        var doc = CreateDocWithVmAndService();
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync(
+            "did:example:123?service=linked-domain",
+            new DidUrlDereferencingOptions { Accept = accept });
+
+        result.DereferencingMetadata.Error.Should().Be("representationNotSupported");
+    }
+
+    [Theory]
+    [InlineData("text/plain")]
+    [InlineData("application/xml")]
+    public async Task DereferenceAsync_ServiceTypeQuery_UnsupportedAccept_ReturnsRepresentationNotSupported(string accept)
+    {
+        var doc = CreateDocWithVmAndService();
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync(
+            "did:example:123?serviceType=LinkedDomains",
+            new DidUrlDereferencingOptions { Accept = accept });
+
+        result.DereferencingMetadata.Error.Should().Be("representationNotSupported");
+    }
+
+    [Theory]
+    [InlineData(DidContentTypes.JsonLd)]
+    [InlineData(DidContentTypes.Json)]
+    public async Task DereferenceAsync_ServiceQuery_DidDocumentAccept_Succeeds(string accept)
+    {
+        var doc = CreateDocWithVmAndService();
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync(
+            "did:example:123?service=linked-domain",
+            new DidUrlDereferencingOptions { Accept = accept });
+
+        result.DereferencingMetadata.Error.Should().BeNull();
+        result.ContentStream.Should().BeOfType<DidDocument>();
+    }
+
+    // --- Service ID normalization (relative ↔ absolute) ---
+
+    [Fact]
+    public async Task DereferenceAsync_ServiceQuery_RelativeServiceId_MatchesAbsoluteQuery()
+    {
+        // Service has relative ID "#svc", query uses absolute "did:example:123#svc"
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            Service =
+            [
+                new Service
+                {
+                    Id = "#svc",
+                    Type = "TestService",
+                    ServiceEndpoint = ServiceEndpointValue.FromUri("https://example.com")
+                }
+            ]
+        };
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync(
+            "did:example:123?service=did:example:123%23svc",
+            new DidUrlDereferencingOptions { Accept = "text/uri-list" });
+
+        result.DereferencingMetadata.ContentType.Should().Be("text/uri-list");
+        result.ContentStream.Should().BeOfType<string>();
+    }
+
+    [Fact]
+    public async Task DereferenceAsync_ServiceQuery_AbsoluteServiceId_MatchesRelativeQuery()
+    {
+        // Service has absolute ID, query uses fragment-only "svc"
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            Service =
+            [
+                new Service
+                {
+                    Id = "did:example:123#svc",
+                    Type = "TestService",
+                    ServiceEndpoint = ServiceEndpointValue.FromUri("https://example.com")
+                }
+            ]
+        };
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync(
+            "did:example:123?service=svc",
+            new DidUrlDereferencingOptions { Accept = "text/uri-list" });
+
+        result.DereferencingMetadata.ContentType.Should().Be("text/uri-list");
+        result.ContentStream.Should().BeOfType<string>();
+    }
+
+    [Fact]
+    public async Task DereferenceAsync_ServiceQuery_RelativeHashId_MatchesRelativeQuery()
+    {
+        // Service has relative ID "#svc", query uses fragment-only "svc"
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            Service =
+            [
+                new Service
+                {
+                    Id = "#svc",
+                    Type = "TestService",
+                    ServiceEndpoint = ServiceEndpointValue.FromUri("https://example.com")
+                }
+            ]
+        };
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync(
+            "did:example:123?service=svc",
+            new DidUrlDereferencingOptions { Accept = "text/uri-list" });
+
+        result.DereferencingMetadata.ContentType.Should().Be("text/uri-list");
+        result.ContentStream.Should().BeOfType<string>();
+    }
+
     // --- Embedded verification method dereferencing ---
 
     [Fact]

--- a/tests/NetDid.Core.Tests/Resolution/DefaultDidUrlDereferencerTests.cs
+++ b/tests/NetDid.Core.Tests/Resolution/DefaultDidUrlDereferencerTests.cs
@@ -573,6 +573,108 @@ public class DefaultDidUrlDereferencerTests
         result.ContentStream.Should().BeOfType<string>();
     }
 
+    // --- serviceType + text/uri-list returns ALL matching services ---
+
+    [Fact]
+    public async Task DereferenceAsync_ServiceTypeQuery_UriList_ReturnsAllMatchingServiceUrls()
+    {
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            Service =
+            [
+                new Service
+                {
+                    Id = "did:example:123#svc-1",
+                    Type = "LinkedDomains",
+                    ServiceEndpoint = ServiceEndpointValue.FromUri("https://one.example.com")
+                },
+                new Service
+                {
+                    Id = "did:example:123#svc-2",
+                    Type = "LinkedDomains",
+                    ServiceEndpoint = ServiceEndpointValue.FromUri("https://two.example.com")
+                },
+                new Service
+                {
+                    Id = "did:example:123#other",
+                    Type = "OtherType",
+                    ServiceEndpoint = ServiceEndpointValue.FromUri("https://other.example.com")
+                }
+            ]
+        };
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync(
+            "did:example:123?serviceType=LinkedDomains",
+            new DidUrlDereferencingOptions { Accept = "text/uri-list" });
+
+        result.DereferencingMetadata.ContentType.Should().Be("text/uri-list");
+        var uriList = (string)result.ContentStream!;
+        uriList.Should().Contain("https://one.example.com/");
+        uriList.Should().Contain("https://two.example.com/");
+        uriList.Should().NotContain("https://other.example.com/");
+    }
+
+    // --- Fragment guard: endpoint URI with existing fragment ---
+
+    [Fact]
+    public async Task DereferenceAsync_ServiceQuery_EndpointWithFragment_DoesNotAppendDidFragment()
+    {
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            Service =
+            [
+                new Service
+                {
+                    Id = "did:example:123#svc",
+                    Type = "TestService",
+                    ServiceEndpoint = ServiceEndpointValue.FromUri("https://example.com/page#section")
+                }
+            ]
+        };
+        SetupResolverSuccess(doc);
+
+        // DID URL has fragment "extra", but endpoint already has "#section"
+        var result = await _dereferencer.DereferenceAsync(
+            "did:example:123?service=svc#extra",
+            new DidUrlDereferencingOptions { Accept = "text/uri-list" });
+
+        result.DereferencingMetadata.ContentType.Should().Be("text/uri-list");
+        var url = (string)result.ContentStream!;
+        // The endpoint's own fragment should be preserved, not replaced
+        url.Should().Contain("#section");
+        url.Should().NotContain("#extra");
+    }
+
+    [Fact]
+    public async Task DereferenceAsync_ServiceQuery_EndpointWithoutFragment_AppendsDidFragment()
+    {
+        var doc = new DidDocument
+        {
+            Id = new Did("did:example:123"),
+            Service =
+            [
+                new Service
+                {
+                    Id = "did:example:123#svc",
+                    Type = "TestService",
+                    ServiceEndpoint = ServiceEndpointValue.FromUri("https://example.com/page")
+                }
+            ]
+        };
+        SetupResolverSuccess(doc);
+
+        var result = await _dereferencer.DereferenceAsync(
+            "did:example:123?service=svc#extra",
+            new DidUrlDereferencingOptions { Accept = "text/uri-list" });
+
+        result.DereferencingMetadata.ContentType.Should().Be("text/uri-list");
+        var url = (string)result.ContentStream!;
+        url.Should().Contain("#extra");
+    }
+
     // --- Embedded verification method dereferencing ---
 
     [Fact]

--- a/tests/NetDid.Tests.W3CConformance/Dereferencing/DereferenceTests.cs
+++ b/tests/NetDid.Tests.W3CConformance/Dereferencing/DereferenceTests.cs
@@ -155,6 +155,26 @@ public class DereferenceTests
 
     [Theory, MemberData(nameof(MethodsWithServices))]
     [Trait("W3CCategory", "did-url-dereferencing")]
+    public async Task ServiceQuery_UnsupportedAccept_ReturnsRepresentationNotSupported(string method)
+    {
+        var (did, doc) = await _factory.CreateDidWithServices(method);
+        var dereferencer = _factory.CreateDereferencer();
+
+        var svc = doc.Service![0];
+        var svcFragment = svc.Id.Contains('#') ? svc.Id[(svc.Id.IndexOf('#') + 1)..] : svc.Id;
+        var didUrl = $"{did}?service={svcFragment}";
+
+        var result = await dereferencer.DereferenceAsync(didUrl,
+            new DidUrlDereferencingOptions { Accept = "text/plain" });
+
+        var passed = result.DereferencingMetadata.Error == "representationNotSupported";
+        ConformanceReportSink.Record(method, "did-url-dereferencing", "7.2", "7.2-10",
+            "Unsupported Accept returns representationNotSupported", passed);
+        result.DereferencingMetadata.Error.Should().Be("representationNotSupported");
+    }
+
+    [Theory, MemberData(nameof(MethodsWithServices))]
+    [Trait("W3CCategory", "did-url-dereferencing")]
     public async Task ServiceFragment_ReturnsService(string method)
     {
         var (did, doc) = await _factory.CreateDidWithServices(method);

--- a/w3c-conformance-report.md
+++ b/w3c-conformance-report.md
@@ -1,14 +1,14 @@
 # W3C DID Core Conformance Report
 
-Generated: 2026-03-16T03:01:43Z
+Generated: 2026-03-16T03:30:19Z
 
 ## Summary
 
 | Method | Total | Passed | Failed |
 |--------|-------|--------|--------|
 | did:key | 57 | 57 | 0 |
-| did:peer | 66 | 66 | 0 |
-| did:webvh | 57 | 57 | 0 |
+| did:peer | 67 | 67 | 0 |
+| did:webvh | 58 | 58 | 0 |
 
 ## did-identifier (section 3.1)
 

--- a/w3c-conformance-report.md
+++ b/w3c-conformance-report.md
@@ -1,6 +1,6 @@
 # W3C DID Core Conformance Report
 
-Generated: 2026-03-16T03:30:19Z
+Generated: 2026-03-16T03:41:30Z
 
 ## Summary
 


### PR DESCRIPTION
## Summary

Addresses the two remaining compliance gaps in `DefaultDidUrlDereferencer` identified in [#29](https://github.com/moisesja/net-did/issues/29#issuecomment-4064719985):

- **Unsupported `Accept` media types** now return `representationNotSupported` instead of incorrectly returning a DID Document. Only `application/did+ld+json`, `application/did+json`, and `text/uri-list` are accepted for service queries.
- **Service ID normalization** resolves relative and absolute URIs before comparison. A service with `id: "#svc"` correctly matches `?service=did:example:123%23svc`, and vice versa.

## Changes

- `DefaultDidUrlDereferencer.cs`: Added `IsDidDocumentContentType()` guard in both `BuildServiceResult` and `serviceType` branches; rewrote `FindServiceById` to normalize IDs via `NormalizeServiceId()`
- 10 new unit tests covering unsupported Accept, both DID document content types, and three service ID normalization scenarios (relative→absolute, absolute→relative, relative→relative)
- 1 new W3C conformance test (7.2-10: unsupported Accept returns representationNotSupported)
- Version bumped to 1.1.1

## Test plan

- [x] All 616 tests pass (302 core, 28 key, 31 peer, 70 webvh, 175 w3c, 10 DI)
- [x] `text/plain` Accept on service query returns `representationNotSupported`
- [x] `#svc` service ID matches absolute query `did:example:123#svc`
- [x] Absolute service ID matches fragment-only query `svc`

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)