### PR TITLE
Fix #33: Return artifact values as string instead of byte[]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ See [`NetDidPRD.md`](NetDidPRD.md) for requirements and architecture of the syst
 4. **Explain Changes**: High-level summary at each step
 5. **Document Results**: Add review section`to 'tasks/todo{timestamp}.md`
 6. **Capture Lessons**: Update 'tasks/lessons.md' after corrections
+7. **Update CHANGELOG.md**: After the successful validation of a task, update the CHANGELOG.md with sufficient details
 
 ## Core Principles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-03-19
+
+### Fixed
+
+- **did:webvh artifact type mismatch** (#33): `DidWebVhMethod.CreateAsync`, `UpdateAsync`, and `DeactivateAsync` now return artifact values as `string` instead of `byte[]`. Consumers using `as string` or `(string)` casts on `Artifacts["did.jsonl"]` and `Artifacts["did.json"]` now receive the expected text content instead of `null`.
+
 ## [1.1.1] - 2026-03-15
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NetDidVersion>1.1.1</NetDidVersion>
+    <NetDidVersion>1.1.2</NetDidVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Deterministic>true</Deterministic>

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ var updatedDoc = result.DidDocument with
 
 var updateResult = await didWebVh.UpdateAsync(result.Did.Value, new DidWebVhUpdateOptions
 {
-    CurrentLogContent = (byte[])result.Artifacts!["did.jsonl"],
+    CurrentLogContent = Encoding.UTF8.GetBytes((string)result.Artifacts!["did.jsonl"]),
     SigningKey = signer,
     NewDocument = updatedDoc
 });

--- a/docs/web-server-setup.md
+++ b/docs/web-server-setup.md
@@ -238,8 +238,8 @@ var updateResult = await method.UpdateAsync(did, new DidWebVhUpdateOptions
 });
 
 // Write updated artifacts to the web server's file system
-File.WriteAllBytes("data/did.jsonl", (byte[])updateResult.Artifacts!["did.jsonl"]);
-File.WriteAllBytes("data/did.json", (byte[])updateResult.Artifacts["did.json"]);
+File.WriteAllText("data/did.jsonl", (string)updateResult.Artifacts!["did.jsonl"]);
+File.WriteAllText("data/did.json", (string)updateResult.Artifacts["did.json"]);
 ```
 
 ## Witness File (Optional)

--- a/samples/NetDid.Samples.DidWebVh/Program.cs
+++ b/samples/NetDid.Samples.DidWebVh/Program.cs
@@ -50,16 +50,14 @@ Console.WriteLine();
 // -------------------------------------------------------
 Console.WriteLine("=== did:webvh — Artifacts ===");
 
-var logContent = (byte[])webVhResult.Artifacts!["did.jsonl"];
-var didJsonContent = (byte[])webVhResult.Artifacts["did.json"];
+var logContent = (string)webVhResult.Artifacts!["did.jsonl"];
+var didJsonContent = (string)webVhResult.Artifacts["did.json"];
 
-Console.WriteLine($"  did.jsonl ({logContent.Length} bytes):");
-var logText = Encoding.UTF8.GetString(logContent);
-Console.WriteLine($"    {logText[..Math.Min(logText.Length, 120)]}...");
+Console.WriteLine($"  did.jsonl ({logContent.Length} chars):");
+Console.WriteLine($"    {logContent[..Math.Min(logContent.Length, 120)]}...");
 
-Console.WriteLine($"  did.json ({didJsonContent.Length} bytes):");
-var didJsonText = Encoding.UTF8.GetString(didJsonContent);
-Console.WriteLine($"    {didJsonText[..Math.Min(didJsonText.Length, 120)]}...");
+Console.WriteLine($"  did.json ({didJsonContent.Length} chars):");
+Console.WriteLine($"    {didJsonContent[..Math.Min(didJsonContent.Length, 120)]}...");
 Console.WriteLine();
 
 // -------------------------------------------------------
@@ -69,7 +67,7 @@ Console.WriteLine("=== did:webvh — Resolve ===");
 
 // In production, did.jsonl is served via HTTPS. Here we mock it:
 var logUrl = DidUrlMapper.MapToLogUrl(webVhResult.Did.Value);
-webVhHttpClient.SetLogResponse(logUrl, logContent);
+webVhHttpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
 
 var webVhResolved = await didWebVh.ResolveAsync(webVhResult.Did.Value);
 Console.WriteLine($"  Resolved: {webVhResolved.DidDocument!.Id}");
@@ -98,19 +96,19 @@ var updatedDoc = webVhResult.DidDocument with
 
 var updateResult = await didWebVh.UpdateAsync(webVhResult.Did.Value, new DidWebVhUpdateOptions
 {
-    CurrentLogContent = logContent,
+    CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
     SigningKey = webVhSigner,
     NewDocument = updatedDoc
 });
 
-var updatedLog = (byte[])updateResult.Artifacts!["did.jsonl"];
-var entries = LogEntrySerializer.ParseJsonLines(updatedLog);
+var updatedLog = (string)updateResult.Artifacts!["did.jsonl"];
+var entries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(updatedLog));
 Console.WriteLine($"  Updated log: {entries.Count} entries");
 Console.WriteLine($"  Version 2:   {entries[1].VersionId}");
 Console.WriteLine($"  Services:    {updateResult.DidDocument.Service!.Count}");
 
 // Verify updated resolve
-webVhHttpClient.SetLogResponse(logUrl, updatedLog);
+webVhHttpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(updatedLog));
 var updatedResolved = await didWebVh.ResolveAsync(webVhResult.Did.Value);
 Console.WriteLine($"  Resolved v2: {updatedResolved.DocumentMetadata!.VersionId}");
 Console.WriteLine();
@@ -136,8 +134,8 @@ var preRotResult = await didWebVh.CreateAsync(new DidWebVhCreateOptions
 });
 
 Console.WriteLine($"  Created: {preRotResult.Did}");
-var preRotLog = (byte[])preRotResult.Artifacts!["did.jsonl"];
-var preRotEntries = LogEntrySerializer.ParseJsonLines(preRotLog);
+var preRotLog = (string)preRotResult.Artifacts!["did.jsonl"];
+var preRotEntries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(preRotLog));
 Console.WriteLine($"  Pre-rotation: {preRotEntries[0].Parameters.Prerotation}");
 Console.WriteLine($"  Committed next key hash: {preRotEntries[0].Parameters.NextKeyHashes![0][..20]}...");
 
@@ -147,7 +145,7 @@ var commitment3 = PreRotationManager.ComputeKeyCommitment(rotationKey3.Multibase
 
 var rotateResult = await didWebVh.UpdateAsync(preRotResult.Did.Value, new DidWebVhUpdateOptions
 {
-    CurrentLogContent = preRotLog,
+    CurrentLogContent = Encoding.UTF8.GetBytes(preRotLog),
     SigningKey = rotationSigner1,
     ParameterUpdates = new DidWebVhParameterUpdates
     {
@@ -157,8 +155,8 @@ var rotateResult = await didWebVh.UpdateAsync(preRotResult.Did.Value, new DidWeb
     }
 });
 
-var rotatedLog = (byte[])rotateResult.Artifacts!["did.jsonl"];
-var rotatedEntries = LogEntrySerializer.ParseJsonLines(rotatedLog);
+var rotatedLog = (string)rotateResult.Artifacts!["did.jsonl"];
+var rotatedEntries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(rotatedLog));
 Console.WriteLine($"  Rotated to key2 at version {rotatedEntries[1].VersionNumber}");
 Console.WriteLine($"  New update key: {rotatedEntries[1].Parameters.UpdateKeys![0][..20]}...");
 Console.WriteLine();
@@ -172,14 +170,14 @@ var deactivateResult = await didWebVh.DeactivateAsync(
     webVhResult.Did.Value,
     new DidWebVhDeactivateOptions
     {
-        CurrentLogContent = updatedLog,
+        CurrentLogContent = Encoding.UTF8.GetBytes(updatedLog),
         SigningKey = webVhSigner
     });
 
 Console.WriteLine($"  Deactivated: {deactivateResult.Success}");
 
-var deactivatedLog = (byte[])deactivateResult.Artifacts!["did.jsonl"];
-webVhHttpClient.SetLogResponse(logUrl, deactivatedLog);
+var deactivatedLog = (string)deactivateResult.Artifacts!["did.jsonl"];
+webVhHttpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(deactivatedLog));
 
 var deactivatedResolved = await didWebVh.ResolveAsync(webVhResult.Did.Value);
 Console.WriteLine($"  Resolved deactivated: {deactivatedResolved.DocumentMetadata!.Deactivated}");

--- a/src/NetDid.Method.WebVh/DidWebVhMethod.cs
+++ b/src/NetDid.Method.WebVh/DidWebVhMethod.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NetDid.Core;
@@ -106,9 +107,9 @@ public sealed class DidWebVhMethod : DidMethodBase
         var did = didTemplate.Replace(ScidGenerator.SafePlaceholder, scid);
         var didValue = new Did(did);
 
-        // Generate artifacts
-        var logContent = LogEntrySerializer.ToJsonLines([finalEntry]);
-        var didJsonContent = DidWebCompatibility.GenerateDidJson(did, finalEntry.State);
+        // Generate artifacts (as UTF-8 strings for consumer convenience)
+        var logContent = Encoding.UTF8.GetString(LogEntrySerializer.ToJsonLines([finalEntry]));
+        var didJsonContent = Encoding.UTF8.GetString(DidWebCompatibility.GenerateDidJson(did, finalEntry.State));
 
         var artifacts = new Dictionary<string, object>
         {
@@ -119,7 +120,7 @@ public sealed class DidWebVhMethod : DidMethodBase
         if (createOptions.WitnessProofs is { Count: > 0 })
         {
             var merged = WitnessValidator.MergeWitnessProofs(null, createOptions.WitnessProofs);
-            artifacts["did-witness.json"] = WitnessValidator.SerializeWitnessFile(merged);
+            artifacts["did-witness.json"] = Encoding.UTF8.GetString(WitnessValidator.SerializeWitnessFile(merged));
         }
 
         return new DidCreateResult
@@ -341,14 +342,14 @@ public sealed class DidWebVhMethod : DidMethodBase
             }
         ];
 
-        // Build updated log
+        // Build updated log (as UTF-8 strings for consumer convenience)
         var allEntries = new List<LogEntry>(entries) { newEntry };
-        var logContent = LogEntrySerializer.ToJsonLines(allEntries);
+        var logContent = Encoding.UTF8.GetString(LogEntrySerializer.ToJsonLines(allEntries));
 
         var updateArtifacts = new Dictionary<string, object>
         {
             ["did.jsonl"] = logContent,
-            ["did.json"] = DidWebCompatibility.GenerateDidJson(did, newDocument)
+            ["did.json"] = Encoding.UTF8.GetString(DidWebCompatibility.GenerateDidJson(did, newDocument))
         };
 
         if (updateOptions.WitnessProofs is { Count: > 0 })
@@ -357,7 +358,7 @@ public sealed class DidWebVhMethod : DidMethodBase
             if (updateOptions.CurrentWitnessContent is not null)
                 existing = WitnessValidator.ParseWitnessFile(updateOptions.CurrentWitnessContent);
             var merged = WitnessValidator.MergeWitnessProofs(existing, updateOptions.WitnessProofs);
-            updateArtifacts["did-witness.json"] = WitnessValidator.SerializeWitnessFile(merged);
+            updateArtifacts["did-witness.json"] = Encoding.UTF8.GetString(WitnessValidator.SerializeWitnessFile(merged));
         }
 
         return new DidUpdateResult
@@ -430,9 +431,9 @@ public sealed class DidWebVhMethod : DidMethodBase
             }
         ];
 
-        // Build updated log
+        // Build updated log (as UTF-8 strings for consumer convenience)
         var allEntries = new List<LogEntry>(entries) { deactivationEntry };
-        var logContent = LogEntrySerializer.ToJsonLines(allEntries);
+        var logContent = Encoding.UTF8.GetString(LogEntrySerializer.ToJsonLines(allEntries));
 
         var deactivateArtifacts = new Dictionary<string, object>
         {
@@ -445,7 +446,7 @@ public sealed class DidWebVhMethod : DidMethodBase
             if (deactivateOptions.CurrentWitnessContent is not null)
                 existing = WitnessValidator.ParseWitnessFile(deactivateOptions.CurrentWitnessContent);
             var merged = WitnessValidator.MergeWitnessProofs(existing, deactivateOptions.WitnessProofs);
-            deactivateArtifacts["did-witness.json"] = WitnessValidator.SerializeWitnessFile(merged);
+            deactivateArtifacts["did-witness.json"] = Encoding.UTF8.GetString(WitnessValidator.SerializeWitnessFile(merged));
         }
 
         return new DidDeactivateResult

--- a/tests/NetDid.Method.WebVh.Tests/DidWebVhMethodTests.cs
+++ b/tests/NetDid.Method.WebVh.Tests/DidWebVhMethodTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using FluentAssertions;
 using NetDid.Core;
 using NetDid.Core.Crypto;
@@ -105,11 +106,11 @@ public class DidWebVhMethodTests
             UpdateKey = signer
         });
 
-        var logContent = (byte[])result.Artifacts!["did.jsonl"];
+        var logContent = (string)result.Artifacts!["did.jsonl"];
         logContent.Should().NotBeEmpty();
 
         // Parse the generated log
-        var entries = LogEntrySerializer.ParseJsonLines(logContent);
+        var entries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(logContent));
         entries.Should().HaveCount(1);
         entries[0].VersionNumber.Should().Be(1);
         entries[0].Parameters.Method.Should().Be("did:webvh:1.0");
@@ -148,8 +149,8 @@ public class DidWebVhMethodTests
             PreRotationCommitments = [commitment]
         });
 
-        var logContent = (byte[])result.Artifacts!["did.jsonl"];
-        var entries = LogEntrySerializer.ParseJsonLines(logContent);
+        var logContent = (string)result.Artifacts!["did.jsonl"];
+        var entries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(logContent));
         entries[0].Parameters.Prerotation.Should().BeTrue();
         entries[0].Parameters.NextKeyHashes.Should().Contain(commitment);
     }
@@ -172,9 +173,9 @@ public class DidWebVhMethodTests
         });
 
         // Set up mock HTTP response
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var logUrl = DidUrlMapper.MapToLogUrl(createResult.Did.Value);
-        httpClient.SetLogResponse(logUrl, logContent);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
 
         // Resolve
         var resolveResult = await method.ResolveAsync(createResult.Did.Value);
@@ -236,7 +237,7 @@ public class DidWebVhMethodTests
             UpdateKey = signer
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         // Update — add a service
@@ -262,7 +263,7 @@ public class DidWebVhMethodTests
 
         var updateResult = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer,
             NewDocument = updatedDoc
         });
@@ -272,8 +273,8 @@ public class DidWebVhMethodTests
         updateResult.Artifacts.Should().ContainKey("did.jsonl");
 
         // Verify the updated log has 2 entries
-        var updatedLog = (byte[])updateResult.Artifacts!["did.jsonl"];
-        var entries = LogEntrySerializer.ParseJsonLines(updatedLog);
+        var updatedLog = (string)updateResult.Artifacts!["did.jsonl"];
+        var entries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(updatedLog));
         entries.Should().HaveCount(2);
         entries[1].VersionNumber.Should().Be(2);
     }
@@ -300,7 +301,7 @@ public class DidWebVhMethodTests
             ]
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         // Update
@@ -319,16 +320,16 @@ public class DidWebVhMethodTests
 
         var updateResult = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer,
             NewDocument = updatedDoc
         });
 
-        var updatedLog = (byte[])updateResult.Artifacts!["did.jsonl"];
+        var updatedLog = (string)updateResult.Artifacts!["did.jsonl"];
 
         // Resolve
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, updatedLog);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(updatedLog));
 
         var resolveResult = await method.ResolveAsync(did);
         resolveResult.DidDocument.Should().NotBeNull();
@@ -350,7 +351,7 @@ public class DidWebVhMethodTests
             UpdateKey = originalKey
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         // Rotate to a new key
@@ -358,7 +359,7 @@ public class DidWebVhMethodTests
 
         var updateResult = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = originalKey,
             ParameterUpdates = new DidWebVhParameterUpdates
             {
@@ -366,8 +367,8 @@ public class DidWebVhMethodTests
             }
         });
 
-        var updatedLog = (byte[])updateResult.Artifacts!["did.jsonl"];
-        var entries = LogEntrySerializer.ParseJsonLines(updatedLog);
+        var updatedLog = (string)updateResult.Artifacts!["did.jsonl"];
+        var entries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(updatedLog));
 
         // The effective updateKeys should be the new key after the update
         entries[1].Parameters.UpdateKeys.Should().Contain(newKey.MultibasePublicKey);
@@ -386,12 +387,12 @@ public class DidWebVhMethodTests
             UpdateKey = authorizedKey
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         var act = () => method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = unauthorizedKey
         });
 
@@ -415,13 +416,13 @@ public class DidWebVhMethodTests
             UpdateKey = signer
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         // Deactivate
         var deactivateResult = await method.DeactivateAsync(did, new DidWebVhDeactivateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer
         });
 
@@ -429,9 +430,9 @@ public class DidWebVhMethodTests
         deactivateResult.Artifacts.Should().ContainKey("did.jsonl");
 
         // Resolve should show deactivated
-        var updatedLog = (byte[])deactivateResult.Artifacts!["did.jsonl"];
+        var updatedLog = (string)deactivateResult.Artifacts!["did.jsonl"];
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, updatedLog);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(updatedLog));
 
         var resolveResult = await method.ResolveAsync(did);
         resolveResult.DidDocument.Should().NotBeNull();
@@ -451,12 +452,12 @@ public class DidWebVhMethodTests
             UpdateKey = authorizedKey
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         var act = () => method.DeactivateAsync(did, new DidWebVhDeactivateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = unauthorizedKey
         });
 
@@ -484,7 +485,7 @@ public class DidWebVhMethodTests
             PreRotationCommitments = [commitment2]
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         // Rotate to key2 — signed by key1 (the current authorized key),
@@ -494,7 +495,7 @@ public class DidWebVhMethodTests
 
         var updateResult = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = key1,
             ParameterUpdates = new DidWebVhParameterUpdates
             {
@@ -505,9 +506,9 @@ public class DidWebVhMethodTests
         });
 
         // Verify the update succeeded and is resolvable
-        var updatedLog = (byte[])updateResult.Artifacts!["did.jsonl"];
+        var updatedLog = (string)updateResult.Artifacts!["did.jsonl"];
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, updatedLog);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(updatedLog));
 
         var resolveResult = await method.ResolveAsync(did);
         resolveResult.DidDocument.Should().NotBeNull();
@@ -567,40 +568,40 @@ public class DidWebVhMethodTests
             UpdateKey = signer
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         // First update
         var update1 = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer
         });
-        logContent = (byte[])update1.Artifacts!["did.jsonl"];
+        logContent = (string)update1.Artifacts!["did.jsonl"];
 
         // Second update
         var update2 = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer
         });
-        logContent = (byte[])update2.Artifacts!["did.jsonl"];
+        logContent = (string)update2.Artifacts!["did.jsonl"];
 
         // Third update
         var update3 = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer
         });
-        logContent = (byte[])update3.Artifacts!["did.jsonl"];
+        logContent = (string)update3.Artifacts!["did.jsonl"];
 
         // Verify 4 entries total
-        var entries = LogEntrySerializer.ParseJsonLines(logContent);
+        var entries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(logContent));
         entries.Should().HaveCount(4);
 
         // Resolve should return the latest document
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, logContent);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
 
         var resolveResult = await method.ResolveAsync(did);
         resolveResult.DidDocument.Should().NotBeNull();
@@ -623,26 +624,26 @@ public class DidWebVhMethodTests
             UpdateKey = signer
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         // First update
         var update1 = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer
         });
-        logContent = (byte[])update1.Artifacts!["did.jsonl"];
+        logContent = (string)update1.Artifacts!["did.jsonl"];
 
         // Second update
         var update2 = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer
         });
-        logContent = (byte[])update2.Artifacts!["did.jsonl"];
+        logContent = (string)update2.Artifacts!["did.jsonl"];
 
-        var entries = LogEntrySerializer.ParseJsonLines(logContent);
+        var entries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(logContent));
         entries.Should().HaveCount(3);
 
         // Verify each entry's hash is computed using the PREVIOUS entry's versionId
@@ -676,30 +677,29 @@ public class DidWebVhMethodTests
             Domain = "example.com",
             UpdateKey = signer
         });
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         var update1 = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer
         });
-        logContent = (byte[])update1.Artifacts!["did.jsonl"];
+        logContent = (string)update1.Artifacts!["did.jsonl"];
 
         var update2 = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer
         });
-        logContent = (byte[])update2.Artifacts!["did.jsonl"];
+        logContent = (string)update2.Artifacts!["did.jsonl"];
 
         // Tamper with version 2's versionId (simulate rewriting history)
-        var logText = System.Text.Encoding.UTF8.GetString(logContent);
-        var lines = logText.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var lines = logContent.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         lines.Should().HaveCount(3);
 
         // Parse entry 2 and change its entry hash
-        var entries = LogEntrySerializer.ParseJsonLines(logContent);
+        var entries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(logContent));
         var originalV2Hash = entries[1].EntryHash;
         var tamperedLine = lines[1].Replace(originalV2Hash, "zTamperedHash12345");
         lines[1] = tamperedLine;
@@ -732,10 +732,10 @@ public class DidWebVhMethodTests
             WitnessThreshold = 1
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, logContent);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
         // Intentionally NOT setting witness response
 
         var resolveResult = await method.ResolveAsync(did);
@@ -758,10 +758,10 @@ public class DidWebVhMethodTests
             WitnessThreshold = 1
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, logContent);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
 
         // Set malformed witness file
         var witnessUrl = DidUrlMapper.MapToWitnessUrl(did);
@@ -928,12 +928,12 @@ public class DidWebVhMethodTests
             UpdateKey = signer
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var realDid = createResult.Did.Value;
 
         // Host the log at the correct URL
         var logUrl = DidUrlMapper.MapToLogUrl(realDid);
-        httpClient.SetLogResponse(logUrl, logContent);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
 
         // Resolve with a DIFFERENT SCID — same domain, wrong SCID
         // Both DIDs map to the same URL, but the document inside has the real DID
@@ -943,7 +943,7 @@ public class DidWebVhMethodTests
 
         // The wrong SCID maps to the same URL, so the HTTP client returns the same log
         var wrongLogUrl = DidUrlMapper.MapToLogUrl(wrongDid);
-        httpClient.SetLogResponse(wrongLogUrl, logContent);
+        httpClient.SetLogResponse(wrongLogUrl, Encoding.UTF8.GetBytes(logContent));
 
         var resolveResult = await method.ResolveAsync(wrongDid);
         resolveResult.DidDocument.Should().BeNull();
@@ -966,10 +966,10 @@ public class DidWebVhMethodTests
             UpdateKey = signer
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, logContent);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
 
         var resolveResult = await method.ResolveAsync(did);
 
@@ -1011,10 +1011,10 @@ public class DidWebVhMethodTests
             UpdateKey = signer
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, logContent);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
 
         var resolveResult = await method.ResolveAsync(did, new DidResolutionOptions
         {
@@ -1037,10 +1037,10 @@ public class DidWebVhMethodTests
             UpdateKey = signer
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, logContent);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
 
         // Request a time far in the past — no entry should exist
         var resolveResult = await method.ResolveAsync(did, new DidResolutionOptions
@@ -1064,21 +1064,21 @@ public class DidWebVhMethodTests
             Domain = "example.com",
             UpdateKey = signer
         });
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         var updateResult = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer
         });
-        logContent = (byte[])updateResult.Artifacts!["did.jsonl"];
+        logContent = (string)updateResult.Artifacts!["did.jsonl"];
 
-        var entries = LogEntrySerializer.ParseJsonLines(logContent);
+        var entries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(logContent));
         var v1VersionId = entries[0].VersionId;
 
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, logContent);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
 
         // Request version 1 specifically
         var resolveResult = await method.ResolveAsync(did, new DidResolutionOptions
@@ -1102,22 +1102,21 @@ public class DidWebVhMethodTests
             Domain = "example.com",
             UpdateKey = signer
         });
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         var updateResult = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer
         });
-        logContent = (byte[])updateResult.Artifacts!["did.jsonl"];
+        logContent = (string)updateResult.Artifacts!["did.jsonl"];
 
-        var entries = LogEntrySerializer.ParseJsonLines(logContent);
+        var entries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(logContent));
         var v1VersionId = entries[0].VersionId;
 
         // Corrupt version 2's entry hash
-        var logText = System.Text.Encoding.UTF8.GetString(logContent);
-        var lines = logText.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var lines = logContent.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         var v2Hash = entries[1].EntryHash;
         lines[1] = lines[1].Replace(v2Hash, "zCorruptedHashValue");
         var corruptedLog = System.Text.Encoding.UTF8.GetBytes(string.Join("\n", lines));
@@ -1156,13 +1155,13 @@ public class DidWebVhMethodTests
             PreRotationCommitments = [commitment2]
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         // Try to update with TTL change only — no updateKeys
         var act = () => method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = key1,
             ParameterUpdates = new DidWebVhParameterUpdates
             {
@@ -1190,7 +1189,7 @@ public class DidWebVhMethodTests
             PreRotationCommitments = [commitment2]
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         // Update with both TTL change and key rotation — should succeed
@@ -1199,7 +1198,7 @@ public class DidWebVhMethodTests
 
         var updateResult = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = key1,
             ParameterUpdates = new DidWebVhParameterUpdates
             {
@@ -1213,9 +1212,9 @@ public class DidWebVhMethodTests
         updateResult.DidDocument.Should().NotBeNull();
 
         // Verify it resolves
-        var updatedLog = (byte[])updateResult.Artifacts!["did.jsonl"];
+        var updatedLog = (string)updateResult.Artifacts!["did.jsonl"];
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, updatedLog);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(updatedLog));
 
         var resolveResult = await method.ResolveAsync(did);
         resolveResult.DidDocument.Should().NotBeNull();
@@ -1262,8 +1261,8 @@ public class DidWebVhMethodTests
         });
 
         result.Artifacts.Should().ContainKey("did-witness.json");
-        var witnessContent = (byte[])result.Artifacts!["did-witness.json"];
-        var witnessFile = WitnessValidator.ParseWitnessFile(witnessContent);
+        var witnessContent = (string)result.Artifacts!["did-witness.json"];
+        var witnessFile = WitnessValidator.ParseWitnessFile(Encoding.UTF8.GetBytes(witnessContent));
         witnessFile.Should().NotBeNull();
         witnessFile!.Entries.Should().HaveCount(1);
         witnessFile.Entries[0].VersionId.Should().Be("1-zTestScid");
@@ -1449,16 +1448,16 @@ public class DidWebVhMethodTests
             ]
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
-        var existingWitness = (byte[])createResult.Artifacts["did-witness.json"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
+        var existingWitness = (string)createResult.Artifacts["did-witness.json"];
         var did = createResult.Did.Value;
 
         // Update with new witness proofs, merging with existing
         var updateResult = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer,
-            CurrentWitnessContent = existingWitness,
+            CurrentWitnessContent = Encoding.UTF8.GetBytes(existingWitness),
             WitnessProofs =
             [
                 new WitnessProofEntry
@@ -1481,8 +1480,8 @@ public class DidWebVhMethodTests
         });
 
         updateResult.Artifacts.Should().ContainKey("did-witness.json");
-        var mergedContent = (byte[])updateResult.Artifacts!["did-witness.json"];
-        var merged = WitnessValidator.ParseWitnessFile(mergedContent);
+        var mergedContent = (string)updateResult.Artifacts!["did-witness.json"];
+        var merged = WitnessValidator.ParseWitnessFile(Encoding.UTF8.GetBytes(mergedContent));
         merged.Should().NotBeNull();
         merged!.Entries.Should().HaveCount(2);
     }
@@ -1499,12 +1498,12 @@ public class DidWebVhMethodTests
             UpdateKey = signer
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         var deactivateResult = await method.DeactivateAsync(did, new DidWebVhDeactivateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = signer,
             WitnessProofs =
             [
@@ -1528,8 +1527,8 @@ public class DidWebVhMethodTests
         });
 
         deactivateResult.Artifacts.Should().ContainKey("did-witness.json");
-        var witnessContent = (byte[])deactivateResult.Artifacts!["did-witness.json"];
-        var witnessFile = WitnessValidator.ParseWitnessFile(witnessContent);
+        var witnessContent = (string)deactivateResult.Artifacts!["did-witness.json"];
+        var witnessFile = WitnessValidator.ParseWitnessFile(Encoding.UTF8.GetBytes(witnessContent));
         witnessFile.Should().NotBeNull();
         witnessFile!.Entries.Should().HaveCount(1);
     }
@@ -1550,7 +1549,7 @@ public class DidWebVhMethodTests
             PreRotationCommitments = [commitment2]
         });
 
-        var logContent = (byte[])createResult.Artifacts!["did.jsonl"];
+        var logContent = (string)createResult.Artifacts!["did.jsonl"];
         var did = createResult.Did.Value;
 
         // Manually construct an update entry WITHOUT updateKeys to bypass the API check
@@ -1561,7 +1560,7 @@ public class DidWebVhMethodTests
         // Proper update with key rotation
         var updateResult = await method.UpdateAsync(did, new DidWebVhUpdateOptions
         {
-            CurrentLogContent = logContent,
+            CurrentLogContent = Encoding.UTF8.GetBytes(logContent),
             SigningKey = key1,
             ParameterUpdates = new DidWebVhParameterUpdates
             {
@@ -1572,9 +1571,9 @@ public class DidWebVhMethodTests
         });
 
         // The update succeeds at the API level; verify the log resolves correctly
-        var updatedLog = (byte[])updateResult.Artifacts!["did.jsonl"];
+        var updatedLog = (string)updateResult.Artifacts!["did.jsonl"];
         var logUrl = DidUrlMapper.MapToLogUrl(did);
-        httpClient.SetLogResponse(logUrl, updatedLog);
+        httpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(updatedLog));
 
         var resolveResult = await method.ResolveAsync(did);
         resolveResult.DidDocument.Should().NotBeNull();

--- a/tests/NetDid.Tests.W3CConformance/Infrastructure/TestDidFactory.cs
+++ b/tests/NetDid.Tests.W3CConformance/Infrastructure/TestDidFactory.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using NetDid.Core;
 using NetDid.Core.Crypto;
 using NetDid.Core.Model;
@@ -108,9 +109,9 @@ public sealed class TestDidFactory
         });
 
         // Set up mock HTTP so resolve works
-        var logContent = (byte[])result.Artifacts!["did.jsonl"];
+        var logContent = (string)result.Artifacts!["did.jsonl"];
         var logUrl = DidUrlMapper.MapToLogUrl(result.Did.Value);
-        _webVhHttpClient.SetLogResponse(logUrl, logContent);
+        _webVhHttpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
 
         return (result.Did.Value, result.DidDocument);
     }
@@ -136,9 +137,9 @@ public sealed class TestDidFactory
         });
 
         // Set up mock HTTP so resolve works
-        var logContent = (byte[])result.Artifacts!["did.jsonl"];
+        var logContent = (string)result.Artifacts!["did.jsonl"];
         var logUrl = DidUrlMapper.MapToLogUrl(result.Did.Value);
-        _webVhHttpClient.SetLogResponse(logUrl, logContent);
+        _webVhHttpClient.SetLogResponse(logUrl, Encoding.UTF8.GetBytes(logContent));
 
         return (result.Did.Value, result.DidDocument);
     }

--- a/w3c-conformance-report.md
+++ b/w3c-conformance-report.md
@@ -1,6 +1,6 @@
 # W3C DID Core Conformance Report
 
-Generated: 2026-03-16T03:41:30Z
+Generated: 2026-03-19T13:05:28Z
 
 ## Summary
 


### PR DESCRIPTION
## Summary

- **Root cause**: `DidWebVhMethod` stored artifact values (`did.jsonl`, `did.json`, `did-witness.json`) as `byte[]` in the `Artifacts` dictionary. Consumers using `as string` got `null` because the safe cast silently fails on `byte[]`, making it appear that artifacts were missing.
- **Fix**: Convert artifact values from `byte[]` to `string` via `Encoding.UTF8.GetString()` at the API boundary in `CreateCoreAsync`, `UpdateCoreAsync`, and `DeactivateCoreAsync`. These are JSON/JSONL text — `string` is the natural type for consumers.
- Bumps version to **1.1.2** with changelog entry.

## Test plan

- [x] All 619 tests pass across 6 test projects (Core, Key, Peer, WebVh, W3CConformance, DI)
- [x] Full solution builds with zero errors and zero warnings
- [x] Sample project compiles and reflects updated artifact types
- [ ] Verify TurtleShell SDK consumers can cast `Artifacts["did.jsonl"] as string` successfully

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)