### PR TITLE
Add method discovery surface to IDidMethod (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Method discovery surface on `IDidMethod`** (#36): Three additive, non-breaking properties let wallets and tooling introspect a registered method without constructing options:
+  - `SupportedKeyTypes : IReadOnlyList<KeyType>` — the `KeyType` values the method accepts as input keys (`did:key` and `did:peer` declare every enum member; `did:webvh` declares `[Ed25519]`).
+  - `SupportsRecovery : bool` — whether the method exposes a recovery surface. Defaults to `false`; concrete recovery API per category lands with ND-E9 (#44).
+  - `RecoveryMaterialSpec : RecoveryMaterialSpec?` — `(Kind, SchemaVersion, Encoding)` introspection shape; non-null iff `SupportsRecovery == true`.
+- **`NetDid.Core.Recovery.RecoveryMaterialSpec`**: New record describing the envelope shape of recovery material a method emits at bootstrap and consumes during recovery.
+- **`DidManager` registration invariant** (#36): Construction now fails fast with `InvalidOperationException` when any registered method declares `SupportsRecovery=true` without a non-null `RecoveryMaterialSpec`.
+
+### Changed
+
+- **`DidMethodBase.SupportedKeyTypes`** is **abstract** — every driver inheriting from `DidMethodBase` must declare its accepted set. The `IDidMethod` interface itself still defaults to an empty list via a default interface implementation, so out-of-tree implementers that bypass the base class are not broken.
+
 ## [1.1.2] - 2026-03-19
 
 ### Fixed

--- a/NetDidPRD.md
+++ b/NetDidPRD.md
@@ -164,6 +164,21 @@ public interface IDidMethod
     /// Which CRUD operations this method supports.
     DidMethodCapabilities Capabilities { get; }
 
+    /// Discovery surface (ND-E1): which KeyType values this method accepts as input keys
+    /// when creating a new DID. Wallets and other tooling use this to pick a key type
+    /// without having to construct a DidCreateOptions first. Default: empty.
+    IReadOnlyList<KeyType> SupportedKeyTypes => Array.Empty<KeyType>();
+
+    /// Discovery surface (ND-E1): whether this method exposes a recovery surface.
+    /// When true, RecoveryMaterialSpec MUST be non-null (validated at DidManager
+    /// registration time). Default: false. The concrete recovery API per category
+    /// is co-designed with ND-E9.
+    bool SupportsRecovery => false;
+
+    /// Discovery surface (ND-E1): introspection shape for the recovery material this method
+    /// emits and consumes. Non-null iff SupportsRecovery is true. Default: null.
+    RecoveryMaterialSpec? RecoveryMaterialSpec => null;
+
     /// Create a new DID and return the DID Document + any artifacts (log entries, DNS packets, etc.)
     Task<DidCreateResult> CreateAsync(DidCreateOptions options, CancellationToken ct = default);
 
@@ -176,6 +191,11 @@ public interface IDidMethod
     /// Deactivate a DID (throws NotSupportedException for immutable methods).
     Task<DidDeactivateResult> DeactivateAsync(string did, DidDeactivateOptions options, CancellationToken ct = default);
 }
+
+/// Introspection shape for recovery material. Concrete payload schemas per method
+/// are defined by the recovery API (ND-E9). ND-E1 ships only this shape so consumers
+/// can interrogate registered methods without taking a dependency on per-method types.
+public sealed record RecoveryMaterialSpec(string Kind, int SchemaVersion, string Encoding);
 
 [Flags]
 public enum DidMethodCapabilities
@@ -364,6 +384,15 @@ public abstract class DidMethodBase : IDidMethod, IDidResolver
     public abstract string MethodName { get; }
     public abstract DidMethodCapabilities Capabilities { get; }
 
+    /// Each driver MUST declare the set of KeyType values it accepts as input keys.
+    /// Abstract (not defaulted) because silently advertising an empty supported set
+    /// would lead to wallets and tooling skipping a method that actually works.
+    public abstract IReadOnlyList<KeyType> SupportedKeyTypes { get; }
+
+    /// Default: false. Override and provide a non-null RecoveryMaterialSpec to opt in.
+    public virtual bool SupportsRecovery => false;
+    public virtual RecoveryMaterialSpec? RecoveryMaterialSpec => null;
+
     public async Task<DidCreateResult> CreateAsync(DidCreateOptions options, CancellationToken ct = default)
     {
         if (!Capabilities.HasFlag(DidMethodCapabilities.Create))
@@ -405,6 +434,39 @@ public abstract class DidMethodBase : IDidMethod, IDidResolver
         => throw new OperationNotSupportedException(MethodName, "Deactivate");
 }
 ```
+
+### 3.7 Method Discovery Surface (ND-E1, issue #36)
+
+`IDidMethod` exposes three properties that let wallets and other tooling interrogate a
+registered method without constructing options or hardcoding a `switch (methodName)`:
+
+| Property              | Type                          | Default | Purpose                                                                                |
+| --------------------- | ----------------------------- | ------- | -------------------------------------------------------------------------------------- |
+| `SupportedKeyTypes`   | `IReadOnlyList<KeyType>`      | `[]`    | The set of `KeyType` values the method accepts as input keys when creating a DID.      |
+| `SupportsRecovery`    | `bool`                        | `false` | Whether the method exposes a recovery surface (concrete API per ND-E9 / issue #44).    |
+| `RecoveryMaterialSpec`| `RecoveryMaterialSpec?`       | `null`  | Envelope shape (`Kind`, `SchemaVersion`, `Encoding`) of recovery material.             |
+
+**Default interface implementations** keep the additions non-breaking for any
+out-of-tree class that implements `IDidMethod` directly. **`DidMethodBase` overrides
+`SupportedKeyTypes` as abstract** so every driver in this repo must declare its
+accepted set explicitly — silently advertising an empty set would cause wallets to
+skip a method that actually works.
+
+**Registration invariant.** `DidManager` validates at construction time that any
+registered method with `SupportsRecovery == true` returns a non-null
+`RecoveryMaterialSpec`. The invariant fails fast with `InvalidOperationException`
+rather than letting a misconfigured driver be discovered at recovery time.
+
+**Per-method declared values:**
+
+| Method        | `SupportedKeyTypes`                                                                | `SupportsRecovery` | `RecoveryMaterialSpec` |
+| ------------- | ---------------------------------------------------------------------------------- | ------------------ | ---------------------- |
+| `did:key`     | All seven `KeyType` enum members (multicodec-driven)                               | `false` *          | `null` *               |
+| `did:peer`    | All seven `KeyType` enum members (numalgo 0/2 multicodec, numalgo 4 arbitrary VMs) | `false` *          | `null` *               |
+| `did:webvh`   | `[Ed25519]` (hardcoded update-key requirement)                                     | `false` *          | `null` *               |
+
+\* ND-E9 (issue #44) will define the concrete recovery category and material spec
+for each method.
 
 ---
 

--- a/samples/NetDid.Samples.DependencyInjection/Program.cs
+++ b/samples/NetDid.Samples.DependencyInjection/Program.cs
@@ -87,4 +87,30 @@ Console.WriteLine($"  Method: {keyMethod!.MethodName}");
 Console.WriteLine($"  Capabilities: {keyMethod.Capabilities}");
 Console.WriteLine();
 
+// -------------------------------------------------------
+// 5. Discovery surface — what does each method accept? (issue #36)
+// -------------------------------------------------------
+// Wallets and tooling can interrogate IDidMethod without constructing options
+// or hardcoding a switch on MethodName.
+Console.WriteLine("=== Method Discovery Surface ===");
+
+foreach (var name in manager.RegisteredMethods)
+{
+    var method = manager.GetMethod(name)!;
+    Console.WriteLine($"  did:{method.MethodName}");
+    Console.WriteLine($"    SupportedKeyTypes:    [{string.Join(", ", method.SupportedKeyTypes)}]");
+    Console.WriteLine($"    SupportsRecovery:     {method.SupportsRecovery}");
+    Console.WriteLine($"    RecoveryMaterialSpec: {method.RecoveryMaterialSpec?.ToString() ?? "<null>"}");
+}
+Console.WriteLine();
+
+// Example: pick a method that accepts P-256 before constructing options
+var p256Capable = manager.RegisteredMethods
+    .Select(n => manager.GetMethod(n)!)
+    .Where(m => m.SupportedKeyTypes.Contains(KeyType.P256))
+    .Select(m => m.MethodName)
+    .ToList();
+Console.WriteLine($"  Methods that accept P-256: [{string.Join(", ", p256Capable)}]");
+Console.WriteLine();
+
 Console.WriteLine("Done! DI integration examples completed successfully.");

--- a/src/NetDid.Core/DidManager.cs
+++ b/src/NetDid.Core/DidManager.cs
@@ -14,7 +14,20 @@ public sealed class DidManager : IDidManager, IDidResolver
 
     public DidManager(IEnumerable<IDidMethod> methods)
     {
-        _methods = methods.ToDictionary(m => m.MethodName);
+        var registered = methods.ToDictionary(m => m.MethodName);
+
+        foreach (var method in registered.Values)
+        {
+            if (method.SupportsRecovery && method.RecoveryMaterialSpec is null)
+            {
+                throw new InvalidOperationException(
+                    $"DID method '{method.MethodName}' declares SupportsRecovery=true " +
+                    $"but RecoveryMaterialSpec is null. Drivers that opt into recovery " +
+                    $"MUST provide a non-null RecoveryMaterialSpec.");
+            }
+        }
+
+        _methods = registered;
     }
 
     public IReadOnlyList<string> RegisteredMethods => _methods.Keys.ToList();

--- a/src/NetDid.Core/DidMethodBase.cs
+++ b/src/NetDid.Core/DidMethodBase.cs
@@ -1,6 +1,8 @@
+using NetDid.Core.Crypto;
 using NetDid.Core.Exceptions;
 using NetDid.Core.Model;
 using NetDid.Core.Parsing;
+using NetDid.Core.Recovery;
 
 namespace NetDid.Core;
 
@@ -12,6 +14,24 @@ public abstract class DidMethodBase : IDidMethod, IDidResolver
 {
     public abstract string MethodName { get; }
     public abstract DidMethodCapabilities Capabilities { get; }
+
+    /// <summary>
+    /// The set of <see cref="KeyType"/> values this method accepts as input keys
+    /// when creating a new DID. Concrete drivers MUST declare their accepted set.
+    /// </summary>
+    public abstract IReadOnlyList<KeyType> SupportedKeyTypes { get; }
+
+    /// <summary>
+    /// Whether this method exposes a recovery surface. Default: <c>false</c>.
+    /// When overridden to <c>true</c>, <see cref="RecoveryMaterialSpec"/> MUST be non-null.
+    /// </summary>
+    public virtual bool SupportsRecovery => false;
+
+    /// <summary>
+    /// Introspection shape for the recovery material this method emits and consumes.
+    /// Default: <c>null</c>. Required to be non-null when <see cref="SupportsRecovery"/> is <c>true</c>.
+    /// </summary>
+    public virtual RecoveryMaterialSpec? RecoveryMaterialSpec => null;
 
     public async Task<DidCreateResult> CreateAsync(DidCreateOptions options, CancellationToken ct = default)
     {

--- a/src/NetDid.Core/IDidMethod.cs
+++ b/src/NetDid.Core/IDidMethod.cs
@@ -1,4 +1,6 @@
+using NetDid.Core.Crypto;
 using NetDid.Core.Model;
+using NetDid.Core.Recovery;
 
 namespace NetDid.Core;
 
@@ -12,6 +14,28 @@ public interface IDidMethod
 
     /// <summary>Which CRUD operations this method supports.</summary>
     DidMethodCapabilities Capabilities { get; }
+
+    /// <summary>
+    /// The set of <see cref="KeyType"/> values this method accepts as input keys
+    /// when creating a new DID. Used by wallets and other tooling to discover, without
+    /// constructing options, which key types a registered method will accept.
+    /// Default: empty. Concrete drivers should populate this set.
+    /// </summary>
+    IReadOnlyList<KeyType> SupportedKeyTypes => Array.Empty<KeyType>();
+
+    /// <summary>
+    /// Whether this method exposes a recovery surface. When <c>true</c>,
+    /// <see cref="RecoveryMaterialSpec"/> MUST be non-null. The concrete recovery
+    /// API per category is defined separately (see ND-E9 / issue #44).
+    /// Default: <c>false</c>.
+    /// </summary>
+    bool SupportsRecovery => false;
+
+    /// <summary>
+    /// Introspection shape for the recovery material this method emits and consumes.
+    /// Non-null iff <see cref="SupportsRecovery"/> is <c>true</c>. Default: <c>null</c>.
+    /// </summary>
+    RecoveryMaterialSpec? RecoveryMaterialSpec => null;
 
     /// <summary>Create a new DID and return the DID Document + any artifacts.</summary>
     Task<DidCreateResult> CreateAsync(DidCreateOptions options, CancellationToken ct = default);

--- a/src/NetDid.Core/Recovery/RecoveryMaterialSpec.cs
+++ b/src/NetDid.Core/Recovery/RecoveryMaterialSpec.cs
@@ -1,0 +1,22 @@
+namespace NetDid.Core.Recovery;
+
+/// <summary>
+/// Describes the envelope shape of recovery material a DID method emits at bootstrap
+/// and consumes during a recovery flow. Returned from <see cref="IDidMethod.RecoveryMaterialSpec"/>
+/// when <see cref="IDidMethod.SupportsRecovery"/> is <c>true</c>.
+/// </summary>
+/// <param name="Kind">
+/// Stable identifier for the material shape (e.g. <c>"webvh-log-commitment"</c>,
+/// <c>"key-seed-restoration"</c>). Consumers branch on this value to pick the right
+/// validator and recovery API path. Concrete kinds are defined per method by the
+/// recovery API (see issue #44 / ND-E9).
+/// </param>
+/// <param name="SchemaVersion">
+/// Integer version of the payload schema. Bumped when the wire shape of the material
+/// changes in a non-backward-compatible way.
+/// </param>
+/// <param name="Encoding">
+/// How the material payload is encoded on the wire (e.g. <c>"application/json"</c>,
+/// <c>"base64url"</c>, <c>"multibase-base58btc"</c>).
+/// </param>
+public sealed record RecoveryMaterialSpec(string Kind, int SchemaVersion, string Encoding);

--- a/src/NetDid.Method.Key/DidKeyMethod.cs
+++ b/src/NetDid.Method.Key/DidKeyMethod.cs
@@ -24,6 +24,17 @@ public sealed class DidKeyMethod : DidMethodBase
     public override string MethodName => "key";
     public override DidMethodCapabilities Capabilities => DidMethodCapabilities.Create | DidMethodCapabilities.Resolve;
 
+    public override IReadOnlyList<KeyType> SupportedKeyTypes { get; } =
+    [
+        KeyType.Ed25519,
+        KeyType.X25519,
+        KeyType.P256,
+        KeyType.P384,
+        KeyType.Secp256k1,
+        KeyType.Bls12381G1,
+        KeyType.Bls12381G2,
+    ];
+
     protected override Task<DidCreateResult> CreateCoreAsync(DidCreateOptions options, CancellationToken ct)
     {
         if (options is not DidKeyCreateOptions keyOptions)

--- a/src/NetDid.Method.Peer/DidPeerMethod.cs
+++ b/src/NetDid.Method.Peer/DidPeerMethod.cs
@@ -1,4 +1,5 @@
 using NetDid.Core;
+using NetDid.Core.Crypto;
 using NetDid.Core.Model;
 using NetDid.Core.Parsing;
 
@@ -23,6 +24,17 @@ public sealed class DidPeerMethod : DidMethodBase
 
     public override string MethodName => "peer";
     public override DidMethodCapabilities Capabilities => DidMethodCapabilities.Create | DidMethodCapabilities.Resolve;
+
+    public override IReadOnlyList<KeyType> SupportedKeyTypes { get; } =
+    [
+        KeyType.Ed25519,
+        KeyType.X25519,
+        KeyType.P256,
+        KeyType.P384,
+        KeyType.Secp256k1,
+        KeyType.Bls12381G1,
+        KeyType.Bls12381G2,
+    ];
 
     protected override Task<DidCreateResult> CreateCoreAsync(DidCreateOptions options, CancellationToken ct)
     {

--- a/src/NetDid.Method.WebVh/DidWebVhMethod.cs
+++ b/src/NetDid.Method.WebVh/DidWebVhMethod.cs
@@ -43,6 +43,13 @@ public sealed class DidWebVhMethod : DidMethodBase
         DidMethodCapabilities.Deactivate |
         DidMethodCapabilities.ServiceEndpoints;
 
+    /// <summary>
+    /// did:webvh requires an Ed25519 update key (see <see cref="DidWebVhCreateOptions.UpdateKey"/>).
+    /// Other key types may appear in the DID Document as additional verification methods,
+    /// but only Ed25519 is accepted as the controlling update key.
+    /// </summary>
+    public override IReadOnlyList<KeyType> SupportedKeyTypes { get; } = [KeyType.Ed25519];
+
     protected override async Task<DidCreateResult> CreateCoreAsync(
         DidCreateOptions options, CancellationToken ct)
     {

--- a/tasks/todo20260521-143202.md
+++ b/tasks/todo20260521-143202.md
@@ -1,0 +1,155 @@
+# Issue #36 — Extend `IDidMethod` with key-type and recovery discovery surfaces
+
+**Status:** Implemented + verified (638 tests pass)
+**Related:** [#44 (ND-E9 Recovery API)](https://github.com/moisesja/net-did/issues/44), `net-wallet-mcp#1`
+**Branch (proposed):** `feature/issue-36-method-discovery`
+
+## Goal
+
+Add three additive, non-breaking discovery members to `IDidMethod` so the wallet (`net-wallet-mcp`) can introspect a registered method without hardcoding mirrors of each `*CreateOptions`:
+
+1. `IReadOnlyList<KeyType> SupportedKeyTypes` — which entries of `Crypto/KeyType.cs` the method accepts on create.
+2. `bool SupportsRecovery` — whether the method exposes a recovery surface (concrete API lands in ND-E9 / #44).
+3. `RecoveryMaterialSpec? RecoveryMaterialSpec` — introspection shape (`Kind`, `SchemaVersion`, `Encoding`) for recovery material; non-null iff `SupportsRecovery == true`.
+
+Per the issue: ND-E1 = **introspection shape only**. Concrete payload schemas are co-designed with ND-E9. So existing methods will declare `SupportsRecovery = false` / `RecoveryMaterialSpec = null` for now, and #44 fills these in per category.
+
+## Design
+
+### New type — [`src/NetDid.Core/Recovery/RecoveryMaterialSpec.cs`](src/NetDid.Core/Recovery/RecoveryMaterialSpec.cs)
+
+```csharp
+namespace NetDid.Core.Recovery;
+
+/// <summary>
+/// Describes the envelope shape of recovery material a method emits/consumes.
+/// Concrete payload schemas are defined by ND-E9 per recovery category.
+/// </summary>
+public sealed record RecoveryMaterialSpec(string Kind, int SchemaVersion, string Encoding);
+```
+
+Kept to the stub the issue body endorses. No `RecoveryCategory` enum here — that belongs to ND-E9 alongside the actual recovery API surface.
+
+### `IDidMethod` extension — [`src/NetDid.Core/IDidMethod.cs`](src/NetDid.Core/IDidMethod.cs)
+
+Add three members. Use **default interface implementations** so any out-of-tree implementer that bypasses `DidMethodBase` keeps compiling (true non-breaking):
+
+```csharp
+IReadOnlyList<KeyType> SupportedKeyTypes => Array.Empty<KeyType>();
+bool SupportsRecovery => false;
+RecoveryMaterialSpec? RecoveryMaterialSpec => null;
+```
+
+### `DidMethodBase` — [`src/NetDid.Core/DidMethodBase.cs`](src/NetDid.Core/DidMethodBase.cs)
+
+- `SupportedKeyTypes` → **abstract**. Every concrete driver in this repo must declare its accepted set explicitly; this is a fundamental method trait, not a defaultable one.
+- `SupportsRecovery` → virtual, default `false`.
+- `RecoveryMaterialSpec` → virtual, default `null`.
+- Invariant guard in the base: if `SupportsRecovery == true`, then `RecoveryMaterialSpec` must be non-null. Enforced via debug assertion on first access (or validated in `DidManager` registration — TBD during impl, prefer the latter so it fails fast at startup).
+
+### Per-method values
+
+| Driver | `SupportedKeyTypes` | `SupportsRecovery` | `RecoveryMaterialSpec` |
+|---|---|---|---|
+| `DidKeyMethod` | `[Ed25519, X25519, P256, P384, Secp256k1, Bls12381G1, Bls12381G2]` (every `KeyType` enum entry — `did:key` is multicodec-driven and accepts all) | `false` (filled by ND-E9 seed-restoration category) | `null` |
+| `DidPeerMethod` | Same as `did:key` (numalgo 0/2 use the same multicodec encoding; numalgo 4 carries arbitrary VMs) | `false` | `null` |
+| `DidWebVhMethod` | `[Ed25519]` (hardcoded in `DidWebVhCreateOptions` validation today) | `false` (log/commitment category fills in via ND-E9) | `null` |
+
+We are **not** opening the door for did:webvh to accept non-Ed25519 update keys in this issue. If/when that lands it's a separate change to `DidWebVhCreateOptions`.
+
+### Why not extend `*CreateOptions` instead?
+
+The wallet needs to ask *before* it has options to construct — it picks the key type based on what the method declares. Putting the truth on the method (not the options) is the correct layering and is what the issue asks for.
+
+## Task list
+
+- [ ] Add `src/NetDid.Core/Recovery/RecoveryMaterialSpec.cs`
+- [ ] Extend `IDidMethod` with the three default-implemented members
+- [ ] Mark `SupportedKeyTypes` abstract on `DidMethodBase`; add virtual `SupportsRecovery`/`RecoveryMaterialSpec` with `false`/`null` defaults
+- [ ] Decide & implement registration-time invariant (`SupportsRecovery → RecoveryMaterialSpec != null`) — leaning toward `DidManager` ctor validation
+- [ ] `DidKeyMethod`: declare `SupportedKeyTypes` (all enum values)
+- [ ] `DidPeerMethod`: declare `SupportedKeyTypes` (all enum values)
+- [ ] `DidWebVhMethod`: declare `SupportedKeyTypes` = `[Ed25519]`
+- [ ] Unit tests in each `*.Tests` project: `SupportedKeyTypes` content, `SupportsRecovery == false`, `RecoveryMaterialSpec == null`
+- [ ] Core test for the registration-time invariant (constructed dummy method with `SupportsRecovery=true` and `RecoveryMaterialSpec=null` must fail registration)
+- [ ] Update `NetDidPRD.md` with the new discovery surface
+- [ ] Update `CHANGELOG.md`
+- [ ] Verify no test regressions: `dotnet test`
+
+## Verification
+
+- All existing tests pass unchanged (member additions are additive).
+- New tests cover each driver's declared values.
+- Confirm `INetDidClient` adapter shape in the wallet docs matches what we've shipped (a one-line check, not a code change here).
+
+## Review
+
+### What shipped
+
+- **New type:** [`src/NetDid.Core/Recovery/RecoveryMaterialSpec.cs`](src/NetDid.Core/Recovery/RecoveryMaterialSpec.cs) — `sealed record (Kind, SchemaVersion, Encoding)` per issue stub.
+- **`IDidMethod`** ([src/NetDid.Core/IDidMethod.cs](src/NetDid.Core/IDidMethod.cs)) gained three members with **default interface implementations** (`SupportedKeyTypes = []`, `SupportsRecovery = false`, `RecoveryMaterialSpec = null`). Out-of-tree implementers stay source-compatible.
+- **`DidMethodBase`** ([src/NetDid.Core/DidMethodBase.cs](src/NetDid.Core/DidMethodBase.cs)): `SupportedKeyTypes` is **abstract** (every concrete driver in-repo must declare its accepted set), `SupportsRecovery` / `RecoveryMaterialSpec` virtual with safe defaults.
+- **Registration invariant** ([src/NetDid.Core/DidManager.cs](src/NetDid.Core/DidManager.cs)): constructor throws `InvalidOperationException` if any registered method declares `SupportsRecovery=true` without a `RecoveryMaterialSpec`.
+- **Per-driver overrides:**
+  - [`DidKeyMethod`](src/NetDid.Method.Key/DidKeyMethod.cs) → all seven `KeyType` enum values.
+  - [`DidPeerMethod`](src/NetDid.Method.Peer/DidPeerMethod.cs) → all seven `KeyType` enum values.
+  - [`DidWebVhMethod`](src/NetDid.Method.WebVh/DidWebVhMethod.cs) → `[Ed25519]` only.
+- **Tests added:**
+  - `RecoveryMaterialSpecTests` (3) — value equality + with-expression
+  - `DidManagerTests` invariant tests (3) — recovery-with-spec, recovery-without-spec throws, default state stays valid
+  - `IDidMethodDefaultsTests` (3) — verify the default interface implementations on a bare `IDidMethod`
+  - `DidKeyMethodTests` (4) — declared set matches enum, instance stable, every declared type round-trips through Create, recovery defaults
+  - `DidPeerMethodTests` (3) — same pattern minus the round-trip (multi-numalgo branching not worth the test churn)
+  - `DidWebVhMethodTests` (3) — declared set is `[Ed25519]`, P-256 update key still rejected at Create time, recovery defaults
+- **Docs:** [NetDidPRD.md](NetDidPRD.md) §3.2 updated with the three new members + a stub `RecoveryMaterialSpec` record; new §3.7 "Method Discovery Surface" with per-method table and the registration-invariant note; §3.6 `DidMethodBase` updated with the new abstract/virtual members.
+- **CHANGELOG.md:** new `[Unreleased]` section describing the additive surface, the new record, the registration invariant, and the `DidMethodBase.SupportedKeyTypes` abstract requirement.
+- **Samples:** [`samples/NetDid.Samples.DependencyInjection/Program.cs`](samples/NetDid.Samples.DependencyInjection/Program.cs) gained a "Method Discovery Surface" section that iterates `RegisteredMethods` and prints each method's declared values, plus a wallet-style example that filters methods by `SupportedKeyTypes.Contains(P256)`.
+
+### Verification
+
+- `dotnet build` — clean (0 warnings, 0 errors).
+- `dotnet test` — 638/638 pass across all six test projects.
+- DI sample runtime output confirmed:
+  ```
+  did:key  SupportedKeyTypes: [Ed25519, X25519, P256, P384, Secp256k1, Bls12381G1, Bls12381G2]
+  did:peer SupportedKeyTypes: [Ed25519, X25519, P256, P384, Secp256k1, Bls12381G1, Bls12381G2]
+  Methods that accept P-256: [key, peer]
+  ```
+- `did:key` and `did:peer` sample programs still execute cleanly end-to-end.
+
+### Decisions worth flagging
+
+- Kept `SupportedKeyTypes` **abstract** on `DidMethodBase` (vs. virtual with `[]` default) — chose correctness over did:ethr merge ergonomics. The in-progress did:ethr driver needs to add one line: `public override IReadOnlyList<KeyType> SupportedKeyTypes { get; } = [KeyType.Secp256k1];`.
+- Held `SupportsRecovery = false` on every existing driver. ND-E9 (#44) will fill in the seed-restoration category for `did:key`/`did:peer` and the log/commitment category for `did:webvh`; doing it here would have required guessing schemas that aren't designed yet.
+- `RecoveryMaterialSpec` is a `sealed record` with no enum for `Kind` — kinds are introduced per method by ND-E9, so string is the right choice for now.
+
+---
+
+## Impact on the developer working on `did:ethr`
+
+**Net impact: small, one-time, additive.** No method signatures change, no existing call sites move. They will need to add property overrides on their driver class. Concretely:
+
+### Required when they merge after this lands
+
+1. **`SupportedKeyTypes`** — must override (abstract on `DidMethodBase`). For `did:ethr` this is `[KeyType.Secp256k1]` (Ethereum keys). One line.
+2. **`SupportsRecovery`** — *can* leave at base default (`false`) for now. ERC-1056 owner-change semantics map naturally to a recovery story, but ND-E9 (#44) is where that gets formalized. If they want to opt in early, override to `true` **and** provide `RecoveryMaterialSpec` (else the `DidManager` registration invariant will fail).
+3. **`RecoveryMaterialSpec`** — only needed if they set `SupportsRecovery = true`. Otherwise leave default `null`.
+
+### What won't change for them
+
+- `CreateAsync` / `ResolveAsync` / `UpdateAsync` / `DeactivateAsync` signatures
+- `DidMethodCapabilities` flags
+- `DidCreateOptions` / `DidUpdateOptions` / `DidDeactivateOptions` base records
+- `NetDidBuilder.AddDidEthr(...)` DI pattern (whatever they're modeling on `AddDidKey` etc.)
+- `DidMethodBase` constructor / lifecycle
+
+### Coordination recommendation
+
+- Merge order: land #36 first, then they rebase their feature branch. The conflict footprint is one file (their `DidEthrMethod.cs`) and the resolution is adding ~3 lines.
+- If their branch is close to PR-ready, we can coordinate the merge order so they don't redo a rebase.
+- They do **not** need to wait on #44 to ship their PR — `SupportsRecovery = false` is a valid steady state until ND-E9 defines the ethr recovery category.
+
+### Risk to their work
+
+- If we ship `SupportedKeyTypes` as **abstract** (current plan), their build breaks the moment they pull main until they add the override — but the fix is mechanical (one-line property).
+- If we instead ship it as **virtual with `[]` default**, their build won't break, but they could ship a driver that silently advertises "no supported key types" to the wallet. I prefer the abstract route for correctness; flag if you'd rather minimize their merge friction.

--- a/tests/NetDid.Core.Tests/DidManagerTests.cs
+++ b/tests/NetDid.Core.Tests/DidManagerTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
+using NetDid.Core.Crypto;
 using NetDid.Core.Exceptions;
 using NetDid.Core.Model;
+using NetDid.Core.Recovery;
 using NSubstitute;
 
 namespace NetDid.Core.Tests;
@@ -187,5 +189,83 @@ public class DidManagerTests
     public void ImplementsIDidResolver()
     {
         _manager.Should().BeAssignableTo<IDidResolver>();
+    }
+
+    // --- Registration invariant: SupportsRecovery -> RecoveryMaterialSpec != null (issue #36) ---
+
+    [Fact]
+    public void Ctor_SupportsRecoveryWithoutSpec_Throws()
+    {
+        var broken = Substitute.For<IDidMethod>();
+        broken.MethodName.Returns("broken");
+        broken.SupportsRecovery.Returns(true);
+        broken.RecoveryMaterialSpec.Returns((RecoveryMaterialSpec?)null);
+
+        var act = () => new DidManager([broken]);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*broken*SupportsRecovery*RecoveryMaterialSpec*");
+    }
+
+    [Fact]
+    public void Ctor_SupportsRecoveryWithSpec_Succeeds()
+    {
+        var ok = Substitute.For<IDidMethod>();
+        ok.MethodName.Returns("ok");
+        ok.SupportsRecovery.Returns(true);
+        ok.RecoveryMaterialSpec.Returns(new RecoveryMaterialSpec("test", 1, "application/json"));
+
+        var act = () => new DidManager([ok]);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Ctor_SupportsRecoveryFalseWithNullSpec_Succeeds()
+    {
+        // The invariant only fires when SupportsRecovery=true. Default state must remain valid.
+        var act = () => new DidManager([_keyMethod, _peerMethod]);
+        act.Should().NotThrow();
+    }
+}
+
+public class IDidMethodDefaultsTests
+{
+    /// <summary>Bare implementation that only fills the four required members,
+    /// to verify the C# default interface implementations on IDidMethod.</summary>
+    private sealed class BareMethod : IDidMethod
+    {
+        public string MethodName => "bare";
+        public DidMethodCapabilities Capabilities => DidMethodCapabilities.None;
+
+        public Task<DidCreateResult> CreateAsync(DidCreateOptions options, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<DidResolutionResult> ResolveAsync(string did, DidResolutionOptions? options = null, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<DidUpdateResult> UpdateAsync(string did, DidUpdateOptions options, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task<DidDeactivateResult> DeactivateAsync(string did, DidDeactivateOptions options, CancellationToken ct = default)
+            => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void SupportedKeyTypes_DefaultIsEmpty()
+    {
+        IDidMethod m = new BareMethod();
+        m.SupportedKeyTypes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SupportsRecovery_DefaultIsFalse()
+    {
+        IDidMethod m = new BareMethod();
+        m.SupportsRecovery.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RecoveryMaterialSpec_DefaultIsNull()
+    {
+        IDidMethod m = new BareMethod();
+        m.RecoveryMaterialSpec.Should().BeNull();
     }
 }

--- a/tests/NetDid.Core.Tests/Recovery/RecoveryMaterialSpecTests.cs
+++ b/tests/NetDid.Core.Tests/Recovery/RecoveryMaterialSpecTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using NetDid.Core.Recovery;
+
+namespace NetDid.Core.Tests.Recovery;
+
+public class RecoveryMaterialSpecTests
+{
+    [Fact]
+    public void Constructor_AssignsAllProperties()
+    {
+        var spec = new RecoveryMaterialSpec(
+            Kind: "webvh-log-commitment",
+            SchemaVersion: 1,
+            Encoding: "application/json");
+
+        spec.Kind.Should().Be("webvh-log-commitment");
+        spec.SchemaVersion.Should().Be(1);
+        spec.Encoding.Should().Be("application/json");
+    }
+
+    [Fact]
+    public void Equality_IsValueBased()
+    {
+        var a = new RecoveryMaterialSpec("k", 1, "e");
+        var b = new RecoveryMaterialSpec("k", 1, "e");
+        var c = new RecoveryMaterialSpec("k", 2, "e");
+
+        a.Should().Be(b);
+        a.Should().NotBe(c);
+    }
+
+    [Fact]
+    public void WithExpression_ProducesNewInstance()
+    {
+        var v1 = new RecoveryMaterialSpec("k", 1, "e");
+        var v2 = v1 with { SchemaVersion = 2 };
+
+        v2.Kind.Should().Be("k");
+        v2.SchemaVersion.Should().Be(2);
+        v2.Encoding.Should().Be("e");
+        v1.SchemaVersion.Should().Be(1);
+    }
+}

--- a/tests/NetDid.Method.Key.Tests/DidKeyMethodTests.cs
+++ b/tests/NetDid.Method.Key.Tests/DidKeyMethodTests.cs
@@ -391,6 +391,41 @@ public class DidKeyMethodTests
         _method.MethodName.Should().Be("key");
     }
 
+    // --- Discovery surface (issue #36) ---
+
+    [Fact]
+    public void SupportedKeyTypes_ContainsAllKeyTypeEnumValues()
+    {
+        var expected = Enum.GetValues<KeyType>();
+        _method.SupportedKeyTypes.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void SupportedKeyTypes_ReturnsSameInstanceAcrossCalls()
+    {
+        _method.SupportedKeyTypes.Should().BeSameAs(_method.SupportedKeyTypes);
+    }
+
+    [Fact]
+    public async Task SupportedKeyTypes_EveryDeclaredTypeRoundTripsThroughCreate()
+    {
+        foreach (var keyType in _method.SupportedKeyTypes)
+        {
+            var result = await _method.CreateAsync(new DidKeyCreateOptions { KeyType = keyType });
+            result.Did.Value.Should().StartWith("did:key:z",
+                because: $"declared SupportedKeyTypes member {keyType} must actually be creatable");
+        }
+    }
+
+    [Fact]
+    public void SupportsRecovery_IsFalse_UntilRecoveryApiLands()
+    {
+        // ND-E9 (issue #44) will wire the seed-restoration recovery category for did:key.
+        // Until then, the introspection surface must report no recovery.
+        _method.SupportsRecovery.Should().BeFalse();
+        _method.RecoveryMaterialSpec.Should().BeNull();
+    }
+
     /// <summary>Test helper: ISigner that returns uncompressed EC public key bytes.</summary>
     private sealed class UncompressedKeySigner : ISigner
     {

--- a/tests/NetDid.Method.Peer.Tests/DidPeerMethodTests.cs
+++ b/tests/NetDid.Method.Peer.Tests/DidPeerMethodTests.cs
@@ -812,4 +812,28 @@ public class DidPeerMethodTests
     {
         _method.MethodName.Should().Be("peer");
     }
+
+    // --- Discovery surface (issue #36) ---
+
+    [Fact]
+    public void SupportedKeyTypes_ContainsAllKeyTypeEnumValues()
+    {
+        // did:peer numalgo 0/2 use the same multicodec encoding as did:key, and numalgo 4
+        // can carry arbitrary verification methods, so every KeyType is accepted.
+        var expected = Enum.GetValues<KeyType>();
+        _method.SupportedKeyTypes.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void SupportedKeyTypes_ReturnsSameInstanceAcrossCalls()
+    {
+        _method.SupportedKeyTypes.Should().BeSameAs(_method.SupportedKeyTypes);
+    }
+
+    [Fact]
+    public void SupportsRecovery_IsFalse_UntilRecoveryApiLands()
+    {
+        _method.SupportsRecovery.Should().BeFalse();
+        _method.RecoveryMaterialSpec.Should().BeNull();
+    }
 }

--- a/tests/NetDid.Method.WebVh.Tests/DidWebVhMethodTests.cs
+++ b/tests/NetDid.Method.WebVh.Tests/DidWebVhMethodTests.cs
@@ -544,6 +544,43 @@ public class DidWebVhMethodTests
         method.CanResolve("did:webvh:QmTest:example.com").Should().BeTrue();
     }
 
+    // --- Discovery surface (issue #36) ---
+
+    [Fact]
+    public void SupportedKeyTypes_IsEd25519Only()
+    {
+        // did:webvh requires Ed25519 update keys; this is hardcoded in CreateAsync.
+        var (method, _) = CreateMethod();
+        method.SupportedKeyTypes.Should().Equal(KeyType.Ed25519);
+    }
+
+    [Fact]
+    public async Task SupportedKeyTypes_NonEd25519UpdateKey_StillRejected()
+    {
+        // The discovery surface is a contract; CreateAsync must still reject non-Ed25519.
+        var (method, _) = CreateMethod();
+        var p256KeyPair = _keyGen.Generate(KeyType.P256);
+        var p256Signer = new KeyPairSigner(p256KeyPair, _crypto);
+
+        var act = () => method.CreateAsync(new DidWebVhCreateOptions
+        {
+            Domain = "example.com",
+            UpdateKey = p256Signer
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Ed25519*");
+    }
+
+    [Fact]
+    public void SupportsRecovery_IsFalse_UntilRecoveryApiLands()
+    {
+        // ND-E9 (issue #44) will wire the log/commitment recovery category for did:webvh.
+        var (method, _) = CreateMethod();
+        method.SupportsRecovery.Should().BeFalse();
+        method.RecoveryMaterialSpec.Should().BeNull();
+    }
+
     [Fact]
     public void CanResolve_DidKey_ReturnsFalse()
     {

--- a/w3c-conformance-report.md
+++ b/w3c-conformance-report.md
@@ -1,6 +1,6 @@
 # W3C DID Core Conformance Report
 
-Generated: 2026-03-19T13:05:28Z
+Generated: 2026-05-21T18:49:41Z
 
 ## Summary
 


### PR DESCRIPTION
## Summary

- Adds three additive, non-breaking discovery members to `IDidMethod` so wallets and tooling (e.g. `net-wallet-mcp`) can introspect a registered method without constructing options or hardcoding a `switch (methodName)`: `SupportedKeyTypes`, `SupportsRecovery`, `RecoveryMaterialSpec`.
- Members ship as default interface implementations on `IDidMethod` (out-of-tree implementers stay source-compatible). `DidMethodBase.SupportedKeyTypes` is abstract — every concrete driver must declare its accepted set. Recovery members stay virtual with `false` / `null` defaults.
- `DidManager` validates at registration time that any method declaring `SupportsRecovery=true` returns a non-null `RecoveryMaterialSpec`; otherwise throws `InvalidOperationException`.

## What changed

| Layer | Change |
|---|---|
| `NetDid.Core` | New `IDidMethod` members + new `RecoveryMaterialSpec` record under `NetDid.Core.Recovery` |
| `DidMethodBase` | `SupportedKeyTypes` abstract; `SupportsRecovery` / `RecoveryMaterialSpec` virtual |
| `DidManager` | Registration-time invariant guard |
| `DidKeyMethod` | `SupportedKeyTypes` = all seven `KeyType` values |
| `DidPeerMethod` | `SupportedKeyTypes` = all seven `KeyType` values |
| `DidWebVhMethod` | `SupportedKeyTypes` = `[Ed25519]` (hardcoded update-key requirement) |
| All three drivers | `SupportsRecovery = false`, `RecoveryMaterialSpec = null` until ND-E9 (#44) defines per-method categories |
| `NetDidPRD.md` | §3.2 / §3.6 updated; new §3.7 Method Discovery Surface with per-method table |
| `CHANGELOG.md` | New `[Unreleased]` section |
| `samples/NetDid.Samples.DependencyInjection` | Demonstrates iterating `manager.RegisteredMethods` and filtering by `SupportedKeyTypes` |
| Tests | 16 new tests across `NetDid.Core.Tests`, `NetDid.Method.{Key,Peer,WebVh}.Tests` |

## Impact on `did:ethr` (in flight)

One line required when rebasing onto this:

```csharp
public override IReadOnlyList<KeyType> SupportedKeyTypes { get; } = [KeyType.Secp256k1];
```

`SupportsRecovery` / `RecoveryMaterialSpec` can stay at base defaults until ND-E9 (#44) defines the ethr recovery category. No CRUD signatures change.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 638/638 pass across all six test projects
- [x] `NetDid.Samples.DependencyInjection` runs and prints the discovery surface for `did:key` and `did:peer`
- [x] `NetDid.Samples.DidKey` and `NetDid.Samples.DidPeer` still execute end-to-end
- [x] CI green on this branch

Closes #36 (ND-E1). Co-designed with #44 (ND-E9) which will populate the concrete recovery categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)