### PR TITLE
Release 1.2.0: discovery surface version bump + audit changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-05-21
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `RecoveryMaterialSpec : RecoveryMaterialSpec?` — `(Kind, SchemaVersion, Encoding)` introspection shape; non-null iff `SupportsRecovery == true`.
 - **`NetDid.Core.Recovery.RecoveryMaterialSpec`**: New record describing the envelope shape of recovery material a method emits at bootstrap and consumes during recovery.
 - **`DidManager` registration invariant** (#36): Construction now fails fast with `InvalidOperationException` when any registered method declares `SupportsRecovery=true` without a non-null `RecoveryMaterialSpec`.
+- **Vulnerability and conformance audit report**: Added `tasks/vulnerability-conformance-audit-20260521.md` with NuGet, RustSec, full test-suite, W3C conformance, and manual security/conformance review results.
 
 ### Changed
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NetDidVersion>1.1.2</NetDidVersion>
+    <NetDidVersion>1.2.0</NetDidVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Deterministic>true</Deterministic>


### PR DESCRIPTION
## Summary

Two commits that missed PR #46's merge window. Cuts `1.2.0` and notes the vulnerability/conformance audit in the same release entry.

- `98e32f2` — `[Unreleased]` → `[1.2.0] - 2026-05-21` in `CHANGELOG.md`; `NetDidVersion` bumped `1.1.2 → 1.2.0`. Minor bump per semver because #36 added public API surface (`IDidMethod` discovery members + `RecoveryMaterialSpec`) additively.
- `68fd748` — Adds the "Vulnerability and conformance audit report" bullet to the `1.2.0` Added section, pointing at `tasks/vulnerability-conformance-audit-20260521.md`.

## Why a separate PR

PR #46 was merged before these commits were pushed. Rather than amend history on the already-merged branch, these ship as a small follow-up.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test` — 638/638 pass (unchanged from #46)
- [ ] CI green on `release/1.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)