### PR TITLE
Fix #50: did:webvh proof authorization bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **did:webvh proof authorization bypass** (#50): `LogChainValidator.ValidateProof` previously authorized proofs using `proof.VerificationMethod.Contains(authorizedKey)` (substring match) while verifying signatures against the key extracted from the DID part only. An attacker could craft `verificationMethod = did:key:<attacker>#<authorized>`, sign with their own key, and have the proof accepted as authorized — allowing unauthorized log updates or deactivation. Authorization now requires exact equality between the signer's multibase key and an entry in `updateKeys`. A new `DataIntegrityProofEngine.ExtractDidKeyMultibase` helper parses `did:key` verification methods and rejects DID/fragment mismatches, path segments, and query strings before authorization is considered.
+
 ### Added
 
 - **Method discovery surface on `IDidMethod`** (#36): Three additive, non-breaking properties let wallets and tooling introspect a registered method without constructing options:

--- a/src/NetDid.Core/Crypto/DataIntegrity/DataIntegrityProofEngine.cs
+++ b/src/NetDid.Core/Crypto/DataIntegrity/DataIntegrityProofEngine.cs
@@ -93,24 +93,61 @@ public sealed class DataIntegrityProofEngine
     }
 
     /// <summary>
+    /// Extract the signer's multibase key from a did:key verification method URL.
+    /// Accepts "did:key:z6Mkf...#z6Mkf..." (DID and fragment MUST match) and
+    /// "did:key:z6Mkf..." (no fragment). Returns null on any malformed input or
+    /// DID/fragment mismatch. Per did:key spec, the fragment is the method-specific id.
+    /// </summary>
+    public static string? ExtractDidKeyMultibase(string verificationMethod)
+    {
+        if (string.IsNullOrEmpty(verificationMethod))
+            return null;
+
+        // Reject anything beyond the optional fragment (path, query, params).
+        if (verificationMethod.IndexOfAny(['?', '/']) >= 0)
+            return null;
+
+        string didPart;
+        string? fragment;
+        var hashIndex = verificationMethod.IndexOf('#');
+        if (hashIndex >= 0)
+        {
+            didPart = verificationMethod[..hashIndex];
+            fragment = verificationMethod[(hashIndex + 1)..];
+        }
+        else
+        {
+            didPart = verificationMethod;
+            fragment = null;
+        }
+
+        if (!didPart.StartsWith("did:key:"))
+            return null;
+
+        var multibaseKey = didPart["did:key:".Length..];
+        if (string.IsNullOrEmpty(multibaseKey))
+            return null;
+
+        // If a fragment is present, it must equal the DID method-specific id.
+        if (fragment is not null && !string.Equals(fragment, multibaseKey, StringComparison.Ordinal))
+            return null;
+
+        return multibaseKey;
+    }
+
+    /// <summary>
     /// Extract the raw Ed25519 public key bytes from a did:key verification method URL.
-    /// Accepts both "did:key:z6Mkf...#z6Mkf..." and "did:key:z6Mkf..." formats.
+    /// Accepts both "did:key:z6Mkf...#z6Mkf..." (DID and fragment MUST match) and
+    /// "did:key:z6Mkf..." formats. Returns null on DID/fragment mismatch.
     /// </summary>
     public static byte[]? ExtractPublicKeyFromDidKey(string verificationMethod)
     {
+        var multibaseKey = ExtractDidKeyMultibase(verificationMethod);
+        if (multibaseKey is null)
+            return null;
+
         try
         {
-            // Strip fragment if present: "did:key:z6Mkf...#z6Mkf..." -> "did:key:z6Mkf..."
-            var didPart = verificationMethod.Contains('#')
-                ? verificationMethod[..verificationMethod.IndexOf('#')]
-                : verificationMethod;
-
-            // Extract method-specific-id: "did:key:z6Mkf..." -> "z6Mkf..."
-            if (!didPart.StartsWith("did:key:"))
-                return null;
-
-            var multibaseKey = didPart["did:key:".Length..];
-
             // Decode multibase -> multicodec-prefixed bytes -> raw key
             var decoded = Multibase.Decode(multibaseKey);
             var (codec, rawKey) = Multicodec.Decode(decoded);

--- a/src/NetDid.Method.WebVh/LogChainValidator.cs
+++ b/src/NetDid.Method.WebVh/LogChainValidator.cs
@@ -175,17 +175,15 @@ internal sealed class LogChainValidator
             // Verify the signer is an authorized update key
             if (authorizedKeys is not null)
             {
-                var publicKey = DataIntegrityProofEngine.ExtractPublicKeyFromDidKey(proof.VerificationMethod);
-                if (publicKey is null) continue;
+                // Exact equality between the signer's multibase key and an entry
+                // in authorizedKeys. Substring matching would allow a proof with
+                // verificationMethod = "did:key:<attacker>#<authorized>" to be
+                // signed by the attacker yet authorized as the legitimate key.
+                var signerKey = DataIntegrityProofEngine.ExtractDidKeyMultibase(proof.VerificationMethod);
+                if (signerKey is null) continue;
 
-                // Check if the proof's key matches any authorized update key
-                foreach (var authorizedKey in authorizedKeys)
-                {
-                    // The verificationMethod is "did:key:{multibase}#{multibase}"
-                    // The authorizedKey is just the multibase portion
-                    if (proof.VerificationMethod.Contains(authorizedKey))
-                        return; // Valid proof from authorized key
-                }
+                if (authorizedKeys.Contains(signerKey, StringComparer.Ordinal))
+                    return; // Valid proof from authorized key
             }
             else
             {

--- a/tasks/todo20260521-160003.md
+++ b/tasks/todo20260521-160003.md
@@ -1,0 +1,124 @@
+# Issue #50 — did:webvh proof authorization bypass
+
+## Branch
+`fix/issue-50-proof-authorization-bypass`
+
+## Vulnerability summary
+
+Confirmed in `src/NetDid.Method.WebVh/LogChainValidator.cs:178-188` and
+`src/NetDid.Core/Crypto/DataIntegrity/DataIntegrityProofEngine.cs:99-128`.
+
+`DataIntegrityProofEngine.ExtractPublicKeyFromDidKey` strips the fragment and
+verifies the signature against the DID-part key only. `LogChainValidator.ValidateProof`
+then authorizes by calling `proof.VerificationMethod.Contains(authorizedKey)`. An
+attacker can sign with their own key and place an authorized multibase key in the
+fragment (`did:key:<attacker>#<authorized>`), passing both checks.
+
+This is a true authorization bypass: signer identity and authorized identity are
+decoupled. Severity: High — matches the issue report.
+
+## Plan
+
+### Code changes
+
+1. **`DataIntegrityProofEngine.cs`** — add a public static helper
+   `ExtractDidKeyMultibase(string verificationMethod)` that returns the signer's
+   multibase key string (the `z…` portion from the DID part) and validates that,
+   if a fragment is present, it matches the DID method-specific id exactly.
+   Returns `null` on any malformed input or fragment mismatch.
+   - Reuse the existing parsing logic in `ExtractPublicKeyFromDidKey` (DRY: have
+     `ExtractPublicKeyFromDidKey` call the new helper and then decode).
+   - Also reject the fragment mismatch at the signature-verification layer so
+     malformed proofs never even reach the authorization step.
+
+2. **`LogChainValidator.cs:151-198`** — replace substring authorization with
+   exact equality:
+   ```csharp
+   var signerKey = DataIntegrityProofEngine.ExtractDidKeyMultibase(proof.VerificationMethod);
+   if (signerKey is null) continue;
+   if (!authorizedKeys.Contains(signerKey, StringComparer.Ordinal)) continue;
+   return; // valid
+   ```
+   - Remove the `foreach (var authorizedKey in authorizedKeys)` substring loop.
+   - Keep the "no key restriction" branch intact.
+
+### Tests (new file: `tests/NetDid.Method.WebVh.Tests/LogChainValidatorAuthorizationTests.cs`)
+
+Cover all 5 scenarios listed in the issue's "Regression tests to add":
+
+1. Attacker key with `verificationMethod = did:key:<attacker>#<authorized>` → **fails**.
+2. Authorized key with `verificationMethod = did:key:<authorized>#<authorized>` → **passes**.
+3. Authorized key with `verificationMethod = did:key:<authorized>` (no fragment) → **passes**.
+4. DID/fragment mismatch where both keys exist but neither match each other → **fails**.
+5. Authorized key as substring inside extra path/query text → **fails**.
+
+Plus a unit test on `ExtractDidKeyMultibase` for fragment mismatch handling.
+
+### Verification
+
+- Run `dotnet test` for the full solution. Expect existing did:webvh
+  create/update/deactivate tests to keep passing (the legitimate code path
+  produces `did:key:<key>#<key>` where DID and fragment match — exact equality
+  on `<key>` still authorizes correctly).
+- Confirm no other call sites depend on substring matching of `VerificationMethod`.
+
+### Documentation
+
+- Update `CHANGELOG.md` under a "Security" section for this fix.
+- Add a review section to this file once done.
+
+## Acceptance criteria (from issue)
+
+- [x] did:webvh validation authorizes proofs using exact signer-key equality.
+- [x] No authorization decision uses substring matching on the full verification method string.
+- [x] Exploit shape (`did:key:<attacker>#<authorized>`) fails validation.
+- [x] Existing did:webvh create/update/deactivate tests still pass.
+- [x] New regression tests cover mismatched DID/fragments and attacker-key proofs.
+
+## Review
+
+### Files changed
+
+- `src/NetDid.Core/Crypto/DataIntegrity/DataIntegrityProofEngine.cs` — added
+  `ExtractDidKeyMultibase(string)` (public static). Refactored
+  `ExtractPublicKeyFromDidKey` to call the new helper, so both signature
+  verification and authorization reject DID/fragment mismatches and any URL
+  containing `?` or `/` after the multibase key.
+- `src/NetDid.Method.WebVh/LogChainValidator.cs` — removed the substring loop;
+  authorization now requires `authorizedKeys.Contains(signerKey, StringComparer.Ordinal)`.
+- `tests/NetDid.Method.WebVh.Tests/LogChainValidatorAuthorizationTests.cs` —
+  11 new tests covering the 5 scenarios from the issue plus unit coverage of
+  the new helper.
+- `CHANGELOG.md` — added `[Unreleased] -> Security` entry.
+
+### Test results
+
+- New tests: 11 passing.
+- Full solution: 649 passing, 0 failures (NetDid.Core.Tests 314,
+  NetDid.Method.WebVh.Tests 84, NetDid.Method.Key.Tests 32,
+  NetDid.Method.Peer.Tests 34, NetDid.Extensions.DependencyInjection.Tests 10,
+  NetDid.Tests.W3CConformance 175).
+
+### Acceptance criteria
+
+- [x] Exact signer-key equality. (`authorizedKeys.Contains(signerKey, StringComparer.Ordinal)`)
+- [x] No substring matching on the verification method. (Helper rejects extra path/query.)
+- [x] Exploit `did:key:<attacker>#<authorized>` fails. (Scenario 1 test.)
+- [x] Existing did:webvh create/update/deactivate tests pass. (Full suite green.)
+- [x] Regression tests for mismatched DID/fragments and attacker-key proofs.
+
+### Behavior diff vs. main
+
+Legitimate create/update/deactivate paths emit `did:key:<mb>#<mb>` where DID
+part and fragment are the same multibase key. The new exact-equality check on
+the DID-part multibase passes for these, and the fragment match check passes
+trivially. Forward-compatible with fragmentless `did:key:<mb>` because the
+helper accepts that form too.
+
+## Notes
+
+- The `ExtractPublicKeyFromDidKey` doc comment claims it accepts both
+  `did:key:z…#z…` and `did:key:z…` formats. The DID Core spec for did:key
+  verification methods uses the `#<multibase>` fragment form, but spec-conformant
+  consumers should reject DID/fragment mismatches. Tightening this here is the
+  right call.

--- a/tests/NetDid.Method.WebVh.Tests/LogChainValidatorAuthorizationTests.cs
+++ b/tests/NetDid.Method.WebVh.Tests/LogChainValidatorAuthorizationTests.cs
@@ -1,0 +1,291 @@
+using System.Text;
+using FluentAssertions;
+using NetCid;
+using NetDid.Core;
+using NetDid.Core.Crypto;
+using NetDid.Core.Crypto.DataIntegrity;
+using NetDid.Core.Crypto.Jcs;
+using NetDid.Core.Exceptions;
+using NetDid.Method.WebVh;
+using NetDid.Method.WebVh.Model;
+
+namespace NetDid.Method.WebVh.Tests;
+
+/// <summary>
+/// Regression tests for issue #50: did:webvh proof authorization bypass.
+///
+/// Before the fix, <c>LogChainValidator.ValidateProof</c> authorized proofs
+/// using <c>proof.VerificationMethod.Contains(authorizedKey)</c>, while the signature
+/// was verified against the key extracted from the DID part only. An attacker could
+/// craft <c>did:key:&lt;attacker&gt;#&lt;authorized&gt;</c> and sign with their own
+/// key, passing both checks.
+/// </summary>
+public class LogChainValidatorAuthorizationTests
+{
+    private readonly DefaultKeyGenerator _keyGen = new();
+    private readonly DefaultCryptoProvider _crypto = new();
+
+    private (DidWebVhMethod Method, MockWebVhHttpClient HttpClient) CreateMethod()
+    {
+        var httpClient = new MockWebVhHttpClient();
+        var method = new DidWebVhMethod(httpClient, _crypto);
+        return (method, httpClient);
+    }
+
+    private (KeyPair KeyPair, ISigner Signer) CreateEd25519()
+    {
+        var keyPair = _keyGen.Generate(KeyType.Ed25519);
+        return (keyPair, new KeyPairSigner(keyPair, _crypto));
+    }
+
+    /// <summary>
+    /// Build a fresh did:webvh log signed by <paramref name="authorizedSigner"/>,
+    /// then return the parsed entries so the test can tamper with the proof.
+    /// </summary>
+    private async Task<(string Did, List<LogEntry> Entries)> CreateLogAsync(ISigner authorizedSigner)
+    {
+        var (method, _) = CreateMethod();
+        var result = await method.CreateAsync(new DidWebVhCreateOptions
+        {
+            Domain = "example.com",
+            UpdateKey = authorizedSigner
+        });
+
+        var jsonl = (string)result.Artifacts!["did.jsonl"];
+        var entries = LogEntrySerializer.ParseJsonLines(Encoding.UTF8.GetBytes(jsonl)).ToList();
+        return (result.Did.Value, entries);
+    }
+
+    /// <summary>
+    /// Re-sign the genesis entry over its canonicalized form (without proof) using
+    /// <paramref name="signerKeyPair"/>'s private key, and overwrite the proof's
+    /// <c>verificationMethod</c> with <paramref name="verificationMethod"/>.
+    /// </summary>
+    private void TamperGenesisProof(
+        LogEntry genesis, KeyPair signerKeyPair, string verificationMethod)
+    {
+        var entryJsonWithoutProof = LogEntrySerializer.SerializeWithoutProof(genesis);
+        var canonical = JsonCanonicalization.CanonicalizeToUtf8(entryJsonWithoutProof);
+        var signature = _crypto.Sign(KeyType.Ed25519, signerKeyPair.PrivateKey, canonical);
+        var proofValue = Multibase.Encode(signature, MultibaseEncoding.Base58Btc);
+
+        var original = genesis.Proof![0];
+        genesis.Proof =
+        [
+            new DataIntegrityProofValue
+            {
+                Type = original.Type,
+                Cryptosuite = original.Cryptosuite,
+                VerificationMethod = verificationMethod,
+                Created = original.Created,
+                ProofPurpose = original.ProofPurpose,
+                ProofValue = proofValue
+            }
+        ];
+    }
+
+    private static byte[] SerializeLog(IEnumerable<LogEntry> entries)
+        => LogEntrySerializer.ToJsonLines(entries.ToList());
+
+    // ================================================================
+    // Scenario 1: attacker key with authorized key in fragment → FAIL
+    // ================================================================
+
+    [Fact]
+    public async Task Issue50_AttackerKeyWithAuthorizedFragment_FailsResolution()
+    {
+        var (authorizedKp, authorizedSigner) = CreateEd25519();
+        var (attackerKp, _) = CreateEd25519();
+        var (did, entries) = await CreateLogAsync(authorizedSigner);
+
+        // Craft the exploit verificationMethod from the issue:
+        // did:key:<attacker>#<authorized>
+        var verificationMethod = $"did:key:{attackerKp.MultibasePublicKey}#{authorizedKp.MultibasePublicKey}";
+
+        // Sign the entry with the attacker's private key so the signature verifies
+        // against the key extracted from the DID part (the attacker's key).
+        TamperGenesisProof(entries[0], attackerKp, verificationMethod);
+
+        var (method, httpClient) = CreateMethod();
+        httpClient.SetLogResponse(
+            DidUrlMapper.MapToLogUrl(did), SerializeLog(entries));
+
+        var resolveResult = await method.ResolveAsync(did);
+
+        resolveResult.DidDocument.Should().BeNull();
+        resolveResult.ResolutionMetadata.Error.Should().NotBeNull();
+    }
+
+    // ================================================================
+    // Scenario 2: authorized key with matching fragment → PASS
+    // (This is the normal/healthy path produced by CreateProofAsync.)
+    // ================================================================
+
+    [Fact]
+    public async Task Issue50_AuthorizedKeyWithMatchingFragment_Resolves()
+    {
+        var (_, authorizedSigner) = CreateEd25519();
+        var (did, entries) = await CreateLogAsync(authorizedSigner);
+
+        // No tampering — verificationMethod is already "did:key:<auth>#<auth>".
+        var (method, httpClient) = CreateMethod();
+        httpClient.SetLogResponse(
+            DidUrlMapper.MapToLogUrl(did), SerializeLog(entries));
+
+        var resolveResult = await method.ResolveAsync(did);
+
+        resolveResult.DidDocument.Should().NotBeNull();
+        resolveResult.ResolutionMetadata.Error.Should().BeNull();
+    }
+
+    // ================================================================
+    // Scenario 3: authorized key with no fragment → PASS
+    // ================================================================
+
+    [Fact]
+    public async Task Issue50_AuthorizedKeyWithoutFragment_Resolves()
+    {
+        var (authorizedKp, authorizedSigner) = CreateEd25519();
+        var (did, entries) = await CreateLogAsync(authorizedSigner);
+
+        // Strip the fragment from the verificationMethod. The signature itself
+        // is unchanged (signed by the authorized key), and the DID-part still
+        // points at the same authorized multibase key.
+        var stripped = $"did:key:{authorizedKp.MultibasePublicKey}";
+        var original = entries[0].Proof![0];
+        entries[0].Proof =
+        [
+            new DataIntegrityProofValue
+            {
+                Type = original.Type,
+                Cryptosuite = original.Cryptosuite,
+                VerificationMethod = stripped,
+                Created = original.Created,
+                ProofPurpose = original.ProofPurpose,
+                ProofValue = original.ProofValue
+            }
+        ];
+
+        var (method, httpClient) = CreateMethod();
+        httpClient.SetLogResponse(
+            DidUrlMapper.MapToLogUrl(did), SerializeLog(entries));
+
+        var resolveResult = await method.ResolveAsync(did);
+
+        resolveResult.DidDocument.Should().NotBeNull();
+        resolveResult.ResolutionMetadata.Error.Should().BeNull();
+    }
+
+    // ================================================================
+    // Scenario 4: DID/fragment mismatch where DID is authorized,
+    // fragment names a different (attacker) key → FAIL
+    // ================================================================
+
+    [Fact]
+    public async Task Issue50_DidFragmentMismatch_FailsResolution()
+    {
+        var (authorizedKp, authorizedSigner) = CreateEd25519();
+        var (attackerKp, _) = CreateEd25519();
+        var (did, entries) = await CreateLogAsync(authorizedSigner);
+
+        // DID part is the authorized key, fragment is the attacker key.
+        // Signature is signed by authorized key (so it WOULD verify), but
+        // the DID/fragment mismatch must cause authorization to reject the proof.
+        var verificationMethod = $"did:key:{authorizedKp.MultibasePublicKey}#{attackerKp.MultibasePublicKey}";
+        TamperGenesisProof(entries[0], authorizedKp, verificationMethod);
+
+        var (method, httpClient) = CreateMethod();
+        httpClient.SetLogResponse(
+            DidUrlMapper.MapToLogUrl(did), SerializeLog(entries));
+
+        var resolveResult = await method.ResolveAsync(did);
+
+        resolveResult.DidDocument.Should().BeNull();
+        resolveResult.ResolutionMetadata.Error.Should().NotBeNull();
+    }
+
+    // ================================================================
+    // Scenario 5: authorized key as substring in extra path text → FAIL
+    // ================================================================
+
+    [Fact]
+    public async Task Issue50_AuthorizedKeyInPathSegment_FailsResolution()
+    {
+        var (authorizedKp, authorizedSigner) = CreateEd25519();
+        var (attackerKp, _) = CreateEd25519();
+        var (did, entries) = await CreateLogAsync(authorizedSigner);
+
+        // Place the authorized key in a path segment. The pre-fix substring match
+        // would have accepted this; the new parser must reject any '/' or '?'.
+        var verificationMethod = $"did:key:{attackerKp.MultibasePublicKey}/{authorizedKp.MultibasePublicKey}";
+        TamperGenesisProof(entries[0], attackerKp, verificationMethod);
+
+        var (method, httpClient) = CreateMethod();
+        httpClient.SetLogResponse(
+            DidUrlMapper.MapToLogUrl(did), SerializeLog(entries));
+
+        var resolveResult = await method.ResolveAsync(did);
+
+        resolveResult.DidDocument.Should().BeNull();
+        resolveResult.ResolutionMetadata.Error.Should().NotBeNull();
+    }
+
+    // ================================================================
+    // Unit-level coverage for the new helper
+    // ================================================================
+
+    [Fact]
+    public void ExtractDidKeyMultibase_MatchingFragment_ReturnsKey()
+    {
+        var (kp, _) = CreateEd25519();
+        var vm = $"did:key:{kp.MultibasePublicKey}#{kp.MultibasePublicKey}";
+
+        DataIntegrityProofEngine.ExtractDidKeyMultibase(vm)
+            .Should().Be(kp.MultibasePublicKey);
+    }
+
+    [Fact]
+    public void ExtractDidKeyMultibase_NoFragment_ReturnsKey()
+    {
+        var (kp, _) = CreateEd25519();
+        var vm = $"did:key:{kp.MultibasePublicKey}";
+
+        DataIntegrityProofEngine.ExtractDidKeyMultibase(vm)
+            .Should().Be(kp.MultibasePublicKey);
+    }
+
+    [Fact]
+    public void ExtractDidKeyMultibase_FragmentMismatch_ReturnsNull()
+    {
+        var (kp1, _) = CreateEd25519();
+        var (kp2, _) = CreateEd25519();
+        var vm = $"did:key:{kp1.MultibasePublicKey}#{kp2.MultibasePublicKey}";
+
+        DataIntegrityProofEngine.ExtractDidKeyMultibase(vm).Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractDidKeyMultibase_PathSegment_ReturnsNull()
+    {
+        var (kp, _) = CreateEd25519();
+        var vm = $"did:key:{kp.MultibasePublicKey}/extra";
+
+        DataIntegrityProofEngine.ExtractDidKeyMultibase(vm).Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractDidKeyMultibase_QueryString_ReturnsNull()
+    {
+        var (kp, _) = CreateEd25519();
+        var vm = $"did:key:{kp.MultibasePublicKey}?foo=bar";
+
+        DataIntegrityProofEngine.ExtractDidKeyMultibase(vm).Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractDidKeyMultibase_NonDidKey_ReturnsNull()
+    {
+        DataIntegrityProofEngine.ExtractDidKeyMultibase("did:web:example.com")
+            .Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #50. `LogChainValidator.ValidateProof` previously authorized proofs using `proof.VerificationMethod.Contains(authorizedKey)` (substring match) while signature verification only used the key extracted from the DID part. An attacker could craft `verificationMethod = did:key:<attacker>#<authorized>`, sign with their own key, and have the proof pass both checks — allowing unauthorized did:webvh log updates or deactivation entries.

- **Authorization** now requires exact equality between the signer's multibase key and an entry in `updateKeys` (`StringComparer.Ordinal`).
- New `DataIntegrityProofEngine.ExtractDidKeyMultibase` helper parses `did:key` verification methods and rejects DID/fragment mismatches plus any `/` or `?` after the multibase key. `ExtractPublicKeyFromDidKey` delegates to it, so signature verification also rejects malformed URLs before authorization is considered.

## Test plan

- [x] New `LogChainValidatorAuthorizationTests` — 11 tests covering all 5 scenarios from the issue:
  - Attacker key with authorized fragment fails
  - Authorized key with matching fragment passes (existing healthy path)
  - Authorized key with no fragment passes
  - DID/fragment mismatch (auth DID, attacker fragment) fails
  - Authorized key in a path segment fails
  - Plus helper unit coverage (matching, no-fragment, mismatch, path, query, non-did:key)
- [x] Full solution: 649/649 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)