### PR TITLE
Fix #52: validate did:peer numalgo 2 key segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **did:peer numalgo 2 accepts malformed key segments** (#52): `Numalgo2Handler.DecodeKeySegment` previously copied each `V`/`A`/`E`/`I`/`D` segment tail directly into `VerificationMethod.PublicKeyMultibase` with no decoding or validation, so a hostile `did:peer:2.V<garbage>` resolved into a DID Document containing impossible key material (invalid base58, unknown multicodec, wrong key length, off-curve EC point). Numalgo 2 now applies the same validation as `did:key` and numalgo 0 — decode multibase, decode multicodec, map to `KeyType`, length-check, and `IsValidEcPoint` — returning `invalidDid` on any failure.
+
 ## [1.2.0] - 2026-05-21
 
 ### Security

--- a/src/NetDid.Method.Peer/Numalgo2Handler.cs
+++ b/src/NetDid.Method.Peer/Numalgo2Handler.cs
@@ -140,6 +140,21 @@ internal sealed class Numalgo2Handler
 
     private static VerificationMethod DecodeKeySegment(string multibaseKey, Did controller, ref int keyIndex)
     {
+        // Validate the embedded Multikey the same way did:key and numalgo 0 do:
+        // decode multibase, decode multicodec, map to KeyType, length-check, EC point-check.
+        // Any failure throws and the outer DidPeerMethod.ResolveCoreAsync returns invalidDid.
+        var decoded = Multibase.Decode(multibaseKey);
+        var (codec, rawKey) = Multicodec.Decode(decoded);
+        var keyType = KeyTypeExtensions.ToKeyType(codec);
+
+        if (!keyType.IsValidKeyLength(rawKey.Length))
+            throw new ArgumentException(
+                $"Invalid key length {rawKey.Length} for {keyType} in numalgo 2 segment.");
+
+        if (!keyType.IsValidEcPoint(rawKey))
+            throw new ArgumentException(
+                $"Invalid EC point for {keyType} in numalgo 2 segment.");
+
         var vmId = $"#key-{keyIndex}";
         var vm = new VerificationMethod
         {

--- a/tasks/todo20260521-161345.md
+++ b/tasks/todo20260521-161345.md
@@ -1,0 +1,64 @@
+# Issue #52 — did:peer numalgo 2 accepts malformed key segments
+
+## Branch
+`fix/issue-52-numalgo2-key-validation`
+
+## Vulnerability summary
+
+Confirmed in `src/NetDid.Method.Peer/Numalgo2Handler.cs:141-153`.
+`DecodeKeySegment` copies the segment tail directly into
+`VerificationMethod.PublicKeyMultibase` with no validation. Compare to
+[Numalgo0Handler.cs:51-66](src/NetDid.Method.Peer/Numalgo0Handler.cs#L51-L66),
+which already decodes multibase, decodes multicodec, maps to KeyType, and
+checks `IsValidKeyLength` + `IsValidEcPoint`.
+
+Result: a hostile `did:peer:2.V<garbage>` resolves into a DID Document
+containing impossible key material. Downstream verifiers fail far from
+the resolver boundary.
+
+Severity: Medium — conformance + hardening.
+
+## Plan
+
+### Code change
+
+`src/NetDid.Method.Peer/Numalgo2Handler.cs` — replace `DecodeKeySegment`
+with a validating implementation that mirrors `Numalgo0Handler.Resolve`:
+
+```csharp
+var decoded = Multibase.Decode(multibaseKey);
+var (codec, rawKey) = Multicodec.Decode(decoded);
+var keyType = KeyTypeExtensions.ToKeyType(codec);
+if (!keyType.IsValidKeyLength(rawKey.Length))
+    throw new ArgumentException("Invalid key length for numalgo 2 segment.");
+if (!keyType.IsValidEcPoint(rawKey))
+    throw new ArgumentException("Invalid EC point for numalgo 2 segment.");
+```
+
+Throwing is sufficient because [DidPeerMethod.ResolveCoreAsync](src/NetDid.Method.Peer/DidPeerMethod.cs#L55-L90)
+already catches every exception and returns `invalidDid`.
+
+### Tests (extend `tests/NetDid.Method.Peer.Tests/DidPeerMethodTests.cs`)
+
+All 6 cases from the issue's "Regression tests to add":
+
+1. Non-multibase key segment → `invalidDid`.
+2. Unknown multicodec → `invalidDid`.
+3. Ed25519 multicodec with wrong payload length → `invalidDid`.
+4. P-256 invalid compressed point → `invalidDid`.
+5. Valid numalgo 2 (already covered by existing tests; spot-check one).
+6. Services-only / empty key cases still behave correctly (existing
+   `Numalgo2_NoKeys_Throws` covers the create path; resolution of a
+   services-only did:peer:2 should still work without keys).
+
+### Verification
+
+- `dotnet test` for the whole solution — 649+ tests must stay green.
+- Existing `Numalgo2_*` tests prove the legitimate path is preserved.
+
+## Acceptance criteria (from issue)
+
+- [x] Key segments validated before becoming verification methods.
+- [x] Malformed material cannot appear in a resolved DID Document.
+- [x] Validation matches did:key for shared Multikey encodings (same helper).
+- [x] New hostile-input tests cover invalid base58, unknown codec, wrong length, invalid EC points.

--- a/tests/NetDid.Method.Peer.Tests/DidPeerMethodTests.cs
+++ b/tests/NetDid.Method.Peer.Tests/DidPeerMethodTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using NetCid;
 using NetDid.Core;
 using NetDid.Core.Crypto;
 using NetDid.Core.Model;
@@ -835,5 +836,103 @@ public class DidPeerMethodTests
     {
         _method.SupportsRecovery.Should().BeFalse();
         _method.RecoveryMaterialSpec.Should().BeNull();
+    }
+
+    // --- Issue #52: numalgo 2 key-segment validation ---
+
+    private static string EncodeMultikey(ulong codec, byte[] payload)
+        => Multibase.Encode(Multicodec.Prefix(codec, payload), MultibaseEncoding.Base58Btc);
+
+    [Fact]
+    public async Task Issue52_Numalgo2_InvalidMultibasePrefix_ReturnsInvalidDid()
+    {
+        // "not-a-real-multibase-key" — first char 'n' is not a known multibase prefix.
+        var result = await _method.ResolveAsync("did:peer:2.Vnot-a-real-multibase-key");
+
+        result.DidDocument.Should().BeNull();
+        result.ResolutionMetadata.Error.Should().Be("invalidDid");
+    }
+
+    [Fact]
+    public async Task Issue52_Numalgo2_UnknownMulticodec_ReturnsInvalidDid()
+    {
+        // Codec 0x55 ("raw") is not a registered key codec — ToKeyType throws.
+        var multikey = EncodeMultikey(0x55, new byte[32]);
+
+        var result = await _method.ResolveAsync($"did:peer:2.V{multikey}");
+
+        result.DidDocument.Should().BeNull();
+        result.ResolutionMetadata.Error.Should().Be("invalidDid");
+    }
+
+    [Fact]
+    public async Task Issue52_Numalgo2_Ed25519WrongLength_ReturnsInvalidDid()
+    {
+        // Ed25519 codec + 1-byte payload (expected: 32).
+        var multikey = EncodeMultikey(Multicodec.Ed25519Pub, new byte[] { 0x42 });
+
+        var result = await _method.ResolveAsync($"did:peer:2.V{multikey}");
+
+        result.DidDocument.Should().BeNull();
+        result.ResolutionMetadata.Error.Should().Be("invalidDid");
+    }
+
+    [Fact]
+    public async Task Issue52_Numalgo2_P256InvalidPoint_ReturnsInvalidDid()
+    {
+        // P-256 codec + 33 bytes of 0xFF: well-formed compressed point header
+        // (0xFF doesn't even look like 0x02/0x03), but the X coordinate is not on the curve.
+        var garbage = new byte[33];
+        Array.Fill<byte>(garbage, 0xFF);
+        var multikey = EncodeMultikey(Multicodec.P256Pub, garbage);
+
+        var result = await _method.ResolveAsync($"did:peer:2.V{multikey}");
+
+        result.DidDocument.Should().BeNull();
+        result.ResolutionMetadata.Error.Should().Be("invalidDid");
+    }
+
+    [Fact]
+    public async Task Issue52_Numalgo2_MalformedKeyAmongValidSegments_StillFails()
+    {
+        // Build a legitimate did:peer:2 with one good Ed25519 key, then append a bad V segment.
+        var goodKey = _keyGen.Generate(KeyType.Ed25519);
+        var goodSigner = new KeyPairSigner(goodKey, _crypto);
+        var good = await _method.CreateAsync(new DidPeerCreateOptions
+        {
+            Numalgo = PeerNumalgo.Two,
+            Keys = [new PeerKeyPurpose(goodSigner, PeerPurpose.Authentication)]
+        });
+
+        var tampered = good.Did.Value + ".Vnot-a-real-multibase-key";
+        var result = await _method.ResolveAsync(tampered);
+
+        result.DidDocument.Should().BeNull();
+        result.ResolutionMetadata.Error.Should().Be("invalidDid");
+    }
+
+    [Fact]
+    public async Task Issue52_Numalgo2_ValidEd25519AndP256_StillResolves()
+    {
+        // Spot-check the legitimate path: a multi-key numalgo 2 with Ed25519 + P-256
+        // continues to resolve after the validation change.
+        var edKey = _keyGen.Generate(KeyType.Ed25519);
+        var p256Key = _keyGen.Generate(KeyType.P256);
+
+        var created = await _method.CreateAsync(new DidPeerCreateOptions
+        {
+            Numalgo = PeerNumalgo.Two,
+            Keys =
+            [
+                new PeerKeyPurpose(new KeyPairSigner(edKey, _crypto), PeerPurpose.Authentication),
+                new PeerKeyPurpose(new KeyPairSigner(p256Key, _crypto), PeerPurpose.Assertion)
+            ]
+        });
+
+        var resolved = await _method.ResolveAsync(created.Did.Value);
+
+        resolved.DidDocument.Should().NotBeNull();
+        resolved.ResolutionMetadata.Error.Should().BeNull();
+        resolved.DidDocument!.VerificationMethod.Should().HaveCount(2);
     }
 }

--- a/w3c-conformance-report.md
+++ b/w3c-conformance-report.md
@@ -1,6 +1,6 @@
 # W3C DID Core Conformance Report
 
-Generated: 2026-05-21T18:49:41Z
+Generated: 2026-05-21T20:16:50Z
 
 ## Summary
 


### PR DESCRIPTION
## Summary

Fixes #52. `Numalgo2Handler.DecodeKeySegment` previously copied each `V`/`A`/`E`/`I`/`D` segment tail directly into `VerificationMethod.PublicKeyMultibase` with no decoding or validation. A hostile `did:peer:2.V<garbage>` resolved into a DID Document containing impossible key material (invalid base58, unknown multicodec, wrong key length, off-curve EC point), causing downstream verifiers to fail far from the resolver boundary.

Numalgo 2 now applies the same Multikey validation already used by `did:key` ([DidKeyMethod.ResolveCoreAsync](src/NetDid.Method.Key/DidKeyMethod.cs#L75-L111)) and numalgo 0 ([Numalgo0Handler.Resolve](src/NetDid.Method.Peer/Numalgo0Handler.cs#L51-L66)): decode multibase, decode multicodec, map to `KeyType`, length-check, then `IsValidEcPoint`. Any failure throws and the existing outer `DidPeerMethod.ResolveCoreAsync` catch turns it into `invalidDid`.

## Test plan

- [x] New `Issue52_*` tests in [DidPeerMethodTests.cs](tests/NetDid.Method.Peer.Tests/DidPeerMethodTests.cs):
  - Invalid multibase prefix → `invalidDid`
  - Unknown multicodec (codec `0x55` "raw") → `invalidDid`
  - Ed25519 codec + 1-byte payload (expected: 32) → `invalidDid`
  - P-256 codec + 33-byte off-curve garbage → `invalidDid`
  - Bad segment appended to an otherwise valid DID → `invalidDid`
  - Legitimate Ed25519 + P-256 numalgo 2 still resolves (spot check)
- [x] Full solution: 655/655 passing (Peer tests went from 34 → 40 with the 6 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)