### PR TITLE
[codex] Refresh NuGet dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **NuGet dependency refresh**: Updated all centrally managed package versions to the latest stable releases on nuget.org. Crypto: `NSec.Cryptography` 24.4.0 → 26.4.0, `NBitcoin.Secp256k1` 3.1.5 → 4.0.0. Microsoft.Extensions.* (`Caching.Memory`, `Logging.Abstractions`, `DependencyInjection`, `DependencyInjection.Abstractions`, `Http`) moved off the 10.0.0-preview channel onto stable `10.0.8`. `Microsoft.IdentityModel.Tokens` 8.3.0 → 8.19.1, `Microsoft.SourceLink.GitHub` 8.0.0 → 10.0.300. Testing: `Microsoft.NET.Test.Sdk` 17.12.0 → 18.6.0, `xunit.runner.visualstudio` 2.8.2 → 3.1.5 (still compatible with xunit v2), `coverlet.collector` 6.0.3 → 10.0.1. `FluentAssertions` intentionally held at 7.0.0 — v8 introduced a paid commercial license (Xceed) that is unsuitable for this open-source library. `Nethermind.Crypto.Bls`, `NetCid`, `xunit`, and `NSubstitute` were already on the latest stable versions and were not changed. All 775 tests across the 6 test projects pass on the new dependency set with no build warnings.
+
 ## [1.3.0] - 2026-05-22
 
 ### Security

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NetDidVersion>1.3.0</NetDidVersion>
+    <NetDidVersion>1.3.1</NetDidVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Deterministic>true</Deterministic>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,29 +4,29 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Cryptography -->
-    <PackageVersion Include="NSec.Cryptography" Version="24.4.0" />
-    <PackageVersion Include="NBitcoin.Secp256k1" Version="3.1.5" />
+    <PackageVersion Include="NSec.Cryptography" Version="26.4.0" />
+    <PackageVersion Include="NBitcoin.Secp256k1" Version="4.0.0" />
     <PackageVersion Include="Nethermind.Crypto.Bls" Version="1.0.5" />
     <!-- Encoding -->
     <PackageVersion Include="NetCid" Version="1.5.0" />
     <!-- Caching -->
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0-preview.1.25080.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <!-- Logging -->
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.1.25080.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <!-- Dependency Injection -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.1.25080.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.1.25080.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0-preview.1.25080.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <!-- Identity / JWK -->
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.3.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
     <!-- Source Link -->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <!-- Testing -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="FluentAssertions" Version="7.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 </Project>

--- a/tasks/todo20260603-123840.md
+++ b/tasks/todo20260603-123840.md
@@ -1,0 +1,14 @@
+# Publish Dependency Updates
+
+## Plan
+
+- [x] Inspect current branch, working tree status, and local diff scope.
+- [x] Validate the dependency refresh with the solution test suite.
+- [ ] Commit the coherent dependency update changes.
+- [ ] Push the branch to origin.
+- [ ] Open a draft pull request against `main`.
+- [ ] Document final validation and PR details in this task log.
+
+## Review
+
+Pending.

--- a/tasks/todo20260603-123840.md
+++ b/tasks/todo20260603-123840.md
@@ -4,11 +4,14 @@
 
 - [x] Inspect current branch, working tree status, and local diff scope.
 - [x] Validate the dependency refresh with the solution test suite.
-- [ ] Commit the coherent dependency update changes.
-- [ ] Push the branch to origin.
-- [ ] Open a draft pull request against `main`.
-- [ ] Document final validation and PR details in this task log.
+- [x] Commit the coherent dependency update changes.
+- [x] Push the branch to origin.
+- [x] Open a draft pull request against `main`.
+- [x] Document final validation and PR details in this task log.
 
 ## Review
 
-Pending.
+- Validation: `dotnet test netdid.sln` passed with 775 tests across 6 test projects.
+- Branch: `dependency-updates`.
+- Initial commit: `d7e0930` (`Refresh NuGet dependencies`).
+- Draft PR: https://github.com/moisesja/net-did/pull/72.

--- a/w3c-conformance-report.md
+++ b/w3c-conformance-report.md
@@ -1,6 +1,6 @@
 # W3C DID Core Conformance Report
 
-Generated: 2026-05-21T21:37:16Z
+Generated: 2026-06-03T16:39:00Z
 
 ## Scope and limitations
 
@@ -113,7 +113,7 @@ method's test project and link it here.
 | Statement | Description | did:key | did:peer | did:webvh |
 |-----------|-------------|----------|----------|----------|
 | 7.2-1 | Fragment dereferencing returns VerificationMethod | PASS | PASS | PASS |
-| 7.2-10 | ContentType is set on successful dereference | PASS | PASS | PASS |
+| 7.2-10 | Unsupported Accept returns representationNotSupported | PASS | PASS | PASS |
 | 7.2-11 | Error is null on successful dereference | PASS | PASS | PASS |
 | 7.2-12 | Error is set on failed dereference | PASS | PASS | N/A |
 | 7.2-2 | Returned VM id contains the requested fragment | PASS | PASS | PASS |


### PR DESCRIPTION
## Summary

- Refresh centrally managed NuGet package versions to current stable releases.
- Move Microsoft.Extensions packages off the .NET 10 preview channel to stable 10.0.8.
- Bump the package version metadata to 1.3.1 and update the changelog.
- Regenerate the W3C DID Core conformance report after the dependency refresh.
- Add the task log for this publish workflow.

## Why

This keeps the library on supported stable dependency versions while preserving the current xUnit v2 and FluentAssertions 7 compatibility choices noted in the changelog.

## Impact

Consumers should get the same public NetDid behavior with updated transitive package baselines. The version metadata now reflects the 1.3.1 dependency-refresh release candidate.

## Validation

- dotnet test netdid.sln passed: 775 tests across 6 test projects.