### PR TITLE
chore(deps): bump NetCrypto 1.0.0 → 1.1.0 (v2.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-06-14
+
+### Changed
+
+- **Bumped `NetCrypto` `1.0.0` → `1.1.0`.** A backward-compatible (additive + hardening) refresh of
+  the cryptography provider; net-did's own public API is unchanged. NetCrypto 1.1.0 adds
+  `IKeyStore.DeriveSharedSecretAsync` (HSM-friendly ECDH), a `Base64Url` codec, and unified AEAD
+  size metadata, and tightens EC public-key validation (wrong-length NIST EC keys now throw a
+  parameter-named `ArgumentException` rather than an opaque `CryptographicException`). Consumers
+  using NetCrypto types transitively pick these up automatically. `DataProofsDotnet.Core`
+  `0.1.0-preview.1` (pinned to NetCrypto `>= 1.0.0`) resolves cleanly to 1.1.0 — the full suite,
+  including did:webvh Data Integrity and all 182 W3C conformance assertions, passes against it.
+
 ## [2.0.0] - 2026-06-13
 
 The crypto/proof externalization refactor. net-did now carries **only DID-method logic** — every

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NetDidVersion>2.0.0</NetDidVersion>
+    <NetDidVersion>2.0.1</NetDidVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Deterministic>true</Deterministic>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <!-- Cryptography (NSec.Cryptography, NBitcoin.Secp256k1, Nethermind.Crypto.Bls
          are no longer pinned here: NetCrypto owns them and brings them transitively.
          Re-add a pin only if a project takes a direct PackageReference. -->
-    <PackageVersion Include="NetCrypto" Version="1.0.0" />
+    <PackageVersion Include="NetCrypto" Version="1.1.0" />
     <!-- Data Integrity proofs (did:webvh) -->
     <PackageVersion Include="DataProofsDotnet.Core" Version="0.1.0-preview.1" />
     <!-- Encoding -->

--- a/w3c-conformance-report.md
+++ b/w3c-conformance-report.md
@@ -1,6 +1,6 @@
 # W3C DID Core Conformance Report
 
-Generated: 2026-06-14T00:13:01Z
+Generated: 2026-06-15T04:13:36Z
 
 ## Scope and limitations
 


### PR DESCRIPTION
Refreshes the cryptography provider to **NetCrypto 1.1.0** and cuts a **2.0.1** patch.

NetCrypto 1.1.0 is a backward-compatible (additive + hardening) release — net-did's own public API is unchanged, hence a patch:
- Adds `IKeyStore.DeriveSharedSecretAsync` (HSM-friendly ECDH), a `Base64Url` codec, unified AEAD size metadata.
- Tightens EC public-key validation (wrong-length NIST EC keys now throw a parameter-named `ArgumentException` instead of an opaque `CryptographicException`).

`DataProofsDotnet.Core 0.1.0-preview.1` pins NetCrypto `>= 1.0.0`, so the graph resolves cleanly to 1.1.0 with no downgrade/conflict warnings.

## Verification
- ✅ `dotnet restore`/`build` clean, no warnings.
- ✅ **770 tests pass** — including did:webvh Data Integrity (DataProofsDotnet → NetCrypto 1.1.0 transitively) and all W3C conformance.
- ✅ Regenerated `w3c-conformance-report.md` re-proves conformance under 1.1.0: did:key 57/57, did:peer 67/67, did:webvh 58/58.

## Release
On merge, tag `v2.0.1` on `main` to publish (`publish.yml` builds the tagged commit). The DataProofsDotnet preview-dependency note from 2.0.0 still applies (NU5104 warning at pack time is expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)